### PR TITLE
Drag and drop, and timing adjustments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1906,9 +1906,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
+      "integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2024.8.1",
+  "version": "2024.8.2.dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dinghy-racing-client-ng",
-      "version": "2024.8.1",
+      "version": "2024.8.2.dev",
       "dependencies": {
         "@stomp/stompjs": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2024.8.1",
+  "version": "2024.8.2.dev",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/public/main.css
+++ b/public/main.css
@@ -120,10 +120,39 @@ fieldset {
 	grid-area: main;
 	overflow: hidden;
 }
+.entry-buttons {
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 1fr;
+}
+.race-entry-view-border {
+	border: solid;
+	border-width: thin;
+}
+.race-entry-view-container {
+	display: flex;
+	align-items: center;
+}
 .race-entries-view {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+}
+.race-entry-view {
+	display: grid;
+	grid-template-columns: 6% 6% 10% 3% 50% 5% 20%;
+	vertical-align: middle;
+	border: solid;
+	border-width: thin;
+}
+.race-entry-view-laps {
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 10%;
+	justify-content: left;
+}
+.race-entry-view-scoring-abbreviation {
+	height: fit-content;
 }
 .race-start-console {
 	height: 100%;

--- a/public/main.css
+++ b/public/main.css
@@ -71,10 +71,6 @@ table {
     border-collapse: collapse;
 	margin: 5px;
 }
-tr.disabled > th, 
-tr.disabled > td {
-	 color: lightgray; 
-}
 th.sail-number {
 	text-align: right;
 }
@@ -115,6 +111,9 @@ fieldset {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+}
+.disabled {
+	color: lightgray;
 }
 .display-port {
 	grid-area: main;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Dinghy Rcaing Client",
-  "name": "Dinghy Rcaing",
+  "name": "Dinghy Racing",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.js
+++ b/src/App.js
@@ -27,10 +27,14 @@ import Authorisation from './controller/authorisation';
 import DownloadRacesForm from './view/DownloadRacesForm';
 import RaceStartConsole from './view/RaceStartConsole';
 import CompetitorsConsole from './view/CompetitorsConsole';
+import ModalDialog from './view/ModalDialog';
+import SetTimeForm from './view/SetTimeForm';
+import Clock from './model/domain-classes/clock';
 
 function App({model, controller}) {
   const [displayPort, setDisplayPort] = React.useState();
   const [roles, setRoles] = React.useState([]);
+  const [showSetTimeForm, setShowSetTimeForm] = React.useState(false);
   
   useEffect(() => {
     const authorisation = new Authorisation();
@@ -73,6 +77,14 @@ function App({model, controller}) {
     setDisplayPort(<DownloadRacesForm key={Date.now()}/>);
   }
 
+  function handleSynchExternalClockClick() {
+    setShowSetTimeForm(true);
+  }
+
+  function closeSetTimeFormDialog() {
+    setShowSetTimeForm(false);
+  }
+
   return (
     <ModelContext.Provider value={model}>
     <ControllerContext.Provider value={controller}>
@@ -104,7 +116,11 @@ function App({model, controller}) {
             <button key={6} type='button' className='list-group-item list-group-item-action' onClick={showDownloadRaces}>Download Races</button>
             : null
           }
-          <button key={7} type='button' className='list-group-item list-group-item-action' onClick={() => {window.location.href = window.origin + '/logout'}}>Logout</button>
+          {roles.includes('ROLE_RACE_OFFICER') ? 
+            <button key={7} type='button' className='list-group-item list-group-item-action' onClick={handleSynchExternalClockClick}>Synch External Clock</button>
+            : null
+          }
+          <button key={8} type='button' className='list-group-item list-group-item-action' onClick={() => {window.location.href = window.origin + '/logout'}}>Logout</button>
         </div>
         <div className="display-port">
           <ErrorBoundary key={Date.now()}>
@@ -112,6 +128,9 @@ function App({model, controller}) {
           </ErrorBoundary>
         </div>
       </div>
+      <ModalDialog show={showSetTimeForm} onClose={() => setShowSetTimeForm(false)} testid={'synch-external-time-dialog'} >
+        <SetTimeForm setTime={Clock.synchToTime} closeParent={closeSetTimeFormDialog} />
+      </ModalDialog>
     </ErrorBoundary>
     </ControllerContext.Provider>
     </ModelContext.Provider>

--- a/src/model/dinghy-racing-model.js
+++ b/src/model/dinghy-racing-model.js
@@ -981,17 +981,17 @@ class DinghyRacingModel {
             }
             // dinghy
             if (!results[2].success) {
-                // entry may not have a crew
-                if (/404/.test(results[2].message)) {
-                    results[2] = {...results[2], 'domainObject': null};
-                }
-                else {
-                    return Promise.resolve(results[2]);
-                }
+                return Promise.resolve(results[3]);
             }
             // crew
             if (!results[3].success) {
-                return Promise.resolve(results[3]);
+                // entry may not have a crew
+                if (/404/.test(results[3].message)) {
+                    results[3] = {...results[3], 'domainObject': null};
+                }
+                else {
+                    return Promise.resolve(results[3]);
+                }
             }
             // laps
             if (!results[4].success) {

--- a/src/model/dinghy-racing-model.test.js
+++ b/src/model/dinghy-racing-model.test.js
@@ -26,7 +26,8 @@ import { httpRootURL, wsRootURL, competitorsCollectionHAL,
     competitorsCollection, competitorChrisMarshall, competitorLouScrew, 
     entriesScorpionAHAL, entriesCometAHAL, entryChrisMarshallDinghy1234HAL, entriesHandicapAHAL,
     entriesScorpionA, entriesCometA, entriesHandicapA,
-    competitorSarahPascal, raceHandicapA, entryChrisMarshallScorpionA1234, competitorOwainDavies, competitorJillMyer } from './__mocks__/test-data';
+    competitorSarahPascal, raceHandicapA, entryChrisMarshallScorpionA1234, competitorJillMyer, 
+    entrySarahPascalScorpionA6745, entryJillMyerCometA826, entryChrisMarshallHandicapA1234 } from './__mocks__/test-data';
 import {
     findByRaceGraduate_AHAL_bigData, signedUpGraduateAHAL_bigData,
     competitorCarmenWhiting, competitorAjDavis, competitorIvanPlatt, competitorNellPowell, competitorGraceRees, competitorArranAshley, competitorMacySmall,
@@ -3125,37 +3126,14 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceScorpionA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/10/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/10') {
+                return Promise.resolve({success: true, domainObject: entryChrisMarshallScorpionA1234});
             }
-            else if (url === 'http://localhost:8081/dinghyracing/api/entries/11/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorSarahPascal});
-            }
-            else if (url === 'http://localhost:8081/dinghyracing/api/entries/10/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
-            }
-            else if (url === 'http://localhost:8081/dinghyracing/api/entries/11/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorOwainDavies});
-            }
-            else {
-                return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/11') {
+                return Promise.resolve({success: true, domainObject: entrySarahPascalScorpionA6745});
             }
         });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/10/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy1234});
-            }
-            else if (url === 'http://localhost:8081/dinghyracing/api/entries/11/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy6745});
-            }
-            else {
-                return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-            }
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': dinghyClassScorpion})});
-        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceScorpionA);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
@@ -3170,28 +3148,11 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceCometA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/19/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorJillMyer});
-            }
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/19/crew') {
-                return Promise.resolve({'success': false, 'message': '404 Not Found'});
-            }
-            else {
-                return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/19') {
+                return Promise.resolve({success: true, domainObject: entryJillMyerCometA826});
             }
         });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/19/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy826});
-            }
-            else {
-                return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-            }
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': dinghyClassComet})});
-        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceCometA);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
@@ -3206,41 +3167,15 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceHandicapA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorJillMyer});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/crew') {
-                return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy1234});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy826});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/2/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassScorpion});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/20') {
+                return Promise.resolve({success: true, domainObject: entryChrisMarshallHandicapA1234});
             }
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/18/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassComet});
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/21') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, 
+                    position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'}});
             }
-            return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
         });
-        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceHandicapA);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
@@ -3281,41 +3216,22 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceHandicapA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorJillMyer});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/crew') {
-                return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy1234});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy826});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/2/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassScorpion});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementationOnce((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/20') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorChrisMarshall, crew: competitorLouScrew, race: raceHandicapA, dinghy: dinghy1234, laps: [], sumOfLapTimes: 0, onLastLap: true, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/20'}});
             }
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/18/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassComet});
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/21') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'}});
             }
-            return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
+        }).mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/20') {
+                return Promise.resolve({success: true, domainObject: entryChrisMarshallHandicapA1234});
+            }
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/21') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, 
+                    position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'}});
+            }
         });
-        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceHandicapA);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
@@ -3356,39 +3272,13 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceHandicapA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorJillMyer});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/crew') {
-                return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy1234});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy826});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/2/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassScorpion});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/20') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorChrisMarshall, crew: competitorLouScrew, race: raceHandicapA, dinghy: dinghy1234, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: true, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/20'}});
             }
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/18/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassComet});
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/21') {
+                return Promise.resolve({success: true, domainObject: {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: true, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'}});
             }
-            return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
         });
         jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceHandicapA);
@@ -3418,10 +3308,9 @@ describe('when searching for entries by race', () => {
             } 
         ] }, _links : { self : { href : 'http://localhost:8081/dinghyracing/api/races/8/signedUp' } }};
 
-        const entriesHandicapA_DNS = [
-            {helm: competitorChrisMarshall, crew: competitorLouScrew, race: raceHandicapA, dinghy: dinghy1234, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: 'DNS', position: null, url: 'http://localhost:8081/dinghyracing/api/entries/20'}, 
-            {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: true, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'}
-        ];
+        const entryChrisMarshall_DNS = {helm: competitorChrisMarshall, crew: competitorLouScrew, race: raceHandicapA, dinghy: dinghy1234, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: 'DNS', position: null, url: 'http://localhost:8081/dinghyracing/api/entries/20'};
+        const entryJillMyer_DNS = {helm: competitorJillMyer, crew: null, race: raceHandicapA, dinghy: dinghy826, laps: [], sumOfLapTimes: 0, onLastLap: true, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/21'};
+        const entriesHandicapA_DNS = [entryChrisMarshall_DNS, entryJillMyer_DNS];
 
         fetch.mockImplementationOnce(() => {
             return Promise.resolve({
@@ -3431,41 +3320,14 @@ describe('when searching for entries by race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceHandicapA})});
-        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/crew') {
-                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/helm') {
-                return Promise.resolve({'success': true, 'domainObject': competitorJillMyer});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/crew') {
-                return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/20/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy1234});
-            };
-            if (url === 'http://localhost:8081/dinghyracing/api/entries/21/dinghy') {
-                return Promise.resolve({'success': true, 'domainObject': dinghy826});
-            };
-            return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-        });
-        jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation((url) => {
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/2/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassScorpion});
+        jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/20') {
+                return Promise.resolve({success: true, domainObject: entryChrisMarshall_DNS});
             }
-            if (url === 'http://localhost:8081/dinghyracing/api/dinghies/18/dinghyClass') {
-                return Promise.resolve({'success': true, 'domainObject': dinghyClassComet});
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/21') {
+                return Promise.resolve({success: true, domainObject: entryJillMyer_DNS});
             }
-            return Promise.resolve({'success': false, 'message': 'Error 404 Not Found'});
         });
-        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
         const promise = dinghyRacingModel.getEntriesByRace(raceHandicapA);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
@@ -3494,7 +3356,7 @@ describe('when searching for entries by race', () => {
         expect(result).toEqual({'success': false, 'message': 'Cannot retrieve race entries without URL for race.'});
     });
     describe('when there are more than 20 entries (default Spring page size) for a race', () => {
-        it(' returns all the entries', async () => {
+        it('returns all the entries', async () => {
             fetch.mockImplementationOnce((resource) => {
                 if (resource === 'http://localhost:8081/dinghyracing/api/entries/search/findByRace?race=http://localhost:8081/dinghyracing/api/races/7') {
                     return Promise.resolve({
@@ -3520,289 +3382,98 @@ describe('when searching for entries by race', () => {
                 }
             });
             const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-            jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceGraduateA})});
-            jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
-                if (url === 'http://localhost:8081/dinghyracing/api/entries/1430/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorCarmenWhiting});
+            jest.spyOn(dinghyRacingModel, 'getEntry').mockImplementation((url) => {
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1430') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorCarmenWhiting, crew: competitorNoelHills, race: raceGraduateA, dinghy: dinghy1, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1430'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1431/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAjDavis});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1431') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorAjDavis, crew: competitorDanielLittle, race: raceGraduateA, dinghy: dinghy290, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1431'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1432/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorIvanPlatt});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1432') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorIvanPlatt, crew: competitorAizaAustin, race: raceGraduateA, dinghy: dinghy2009, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1432'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1433/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorNellPowell});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1433') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorNellPowell, crew: competitorWilliamMorrison, race: raceGraduateA, dinghy: dinghy2097, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1433'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1434/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorGraceRees});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1434') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorGraceRees, crew: competitorAugustKhan, race: raceGraduateA, dinghy: dinghy2373, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1434'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1435/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorArranAshley});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1435') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorArranAshley, crew: competitorYuvrajSheppard, race: raceGraduateA, dinghy: dinghy2471, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1435'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1436/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorMacySmall});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1436') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorMacySmall, crew: competitorMaximFlynn, race: raceGraduateA, dinghy: dinghy2482, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1436'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1437/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDestinyBourne});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1437') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorDestinyBourne, crew: competitorCezarWhelan, race: raceGraduateA, dinghy: dinghy2725, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1437'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1438/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDominicBarnett});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1438') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorDominicBarnett, crew: competitorBaileyPreston, race: raceGraduateA, dinghy: dinghy2849, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1438'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1439/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAlaraTaylor});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1439') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorAlaraTaylor, crew: competitorNadiaBarrow, race: raceGraduateA, dinghy: dinghy2862, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1439'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1440/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorKieraDaniels});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1440') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorKieraDaniels, crew: competitorZimalGrainger, race: raceGraduateA, dinghy: dinghy2889, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1440'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1441/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAmariBarber});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1441') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorAmariBarber, crew: competitorRuqayyahWhittle, race: raceGraduateA, dinghy: dinghy2910, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1441'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1442/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorHazelWheeler});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1442') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorHazelWheeler, crew: competitorJaysonGraves, race: raceGraduateA, dinghy: dinghy2912, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1442'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1443/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLucasMillward});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1443') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorLucasMillward, crew: competitorBellaBourne, race: raceGraduateA, dinghy: dinghy2928, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1443'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1444/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLouiseBarron});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1444') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorLouiseBarron, crew: competitorCobieBaldwin, race: raceGraduateA, dinghy: dinghy2931, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1444'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1445/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAlastairKhatun});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1445') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorAlastairKhatun, crew: competitorIrisSandhu, race: raceGraduateA, dinghy: dinghy2938, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1445'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1446/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorSamsonMcGowan});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1446') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorSamsonMcGowan, crew: competitorEsmeHyde, race: raceGraduateA, dinghy: dinghy2969, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1446'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1447/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorCalebParkinson});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1447') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorCalebParkinson, crew: competitorDakotaMoss, race: raceGraduateA, dinghy: dinghy2970, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1447'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1448/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorInayaRegan});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1448') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorInayaRegan, crew: competitorLeoEaton, race: raceGraduateA, dinghy: dinghy2971, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1448'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1449/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLeiaHaynes});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1449') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorLeiaHaynes, crew: competitorDarcyEmery, race: raceGraduateA, dinghy: dinghy2973, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1449'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1450/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorNatanNewman});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1450') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorNatanNewman, crew: competitorDiegoHoughton, race: raceGraduateA, dinghy: dinghy2985, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1450'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1451/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorJamesonSharpe});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1451') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorJamesonSharpe, crew: competitorShelbyMiller, race: raceGraduateA, dinghy: dinghy2987, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1451'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1452/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorElifPugh});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1452') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorElifPugh, crew: competitorMaceyVaughan, race: raceGraduateA, dinghy: dinghy3006, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1452'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1453/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorWilfredMead});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1453') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorWilfredMead, crew: competitorLaineyAbbott, race: raceGraduateA, dinghy: dinghy3009, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1453'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1454/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorFrankySheppard});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1454') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorFrankySheppard, crew: competitorPaddyLowe, race: raceGraduateA, dinghy: dinghy3014, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1454'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1455/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLeniTyler});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1455') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorLeniTyler, crew: competitorBaaniManning, race: raceGraduateA, dinghy: dinghy3015, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1455'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1456/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorMahnoorHope});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1456') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorMahnoorHope, crew: competitorSarahPritchard, race: raceGraduateA, dinghy: dinghy3020, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1456'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1457/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAnthonyDillon});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1457') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorAnthonyDillon, crew: competitorLucienHoare, race: raceGraduateA, dinghy: dinghy3021, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1457'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1458/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorZackaryLindsay});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1458') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorZackaryLindsay, crew: competitorSerenDuffy, race: raceGraduateA, dinghy: dinghy3022, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1458'}});
                 }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1459/helm') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorKhalilRushton});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1430/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorNoelHills});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1431/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDanielLittle});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1432/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAizaAustin});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1433/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorWilliamMorrison});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1434/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorAugustKhan});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1435/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorYuvrajSheppard});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1436/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorMaximFlynn});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1437/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorCezarWhelan});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1438/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorBaileyPreston});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1439/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorNadiaBarrow});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1440/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorZimalGrainger});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1441/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorRuqayyahWhittle});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1442/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorJaysonGraves});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1443/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorBellaBourne});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1444/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorCobieBaldwin});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1445/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorIrisSandhu});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1446/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorEsmeHyde});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1447/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDakotaMoss});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1448/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLeoEaton});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1449/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDarcyEmery});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1450/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorDiegoHoughton});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1451/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorShelbyMiller});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1452/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorMaceyVaughan});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1453/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLaineyAbbott});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1454/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorPaddyLowe});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1455/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorBaaniManning});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1456/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorSarahPritchard});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1457/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorLucienHoare});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1458/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorSerenDuffy});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1459/crew') {
-                    return Promise.resolve({'success': true, 'domainObject': competitorBiancaSwan});
-                }
-                else {
-                    return Promise.resolve({'success': false, 'message': 'Unable to identify competitor.'});
+                if (url === 'http://localhost:8081/dinghyracing/api/entries/1459') {
+                    return Promise.resolve({success: true, domainObject: {helm: competitorKhalilRushton, crew: competitorBiancaSwan, race: raceGraduateA, dinghy: dinghy3088, laps: [], sumOfLapTimes: 0, onLastLap: false, finishedRace: false, scoringAbbreviation: null, position: null, url: 'http://localhost:8081/dinghyracing/api/entries/1459'}});
                 }
             });
-            jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation((url) => {
-                if (url === 'http://localhost:8081/dinghyracing/api/entries/1430/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy1});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1431/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy290});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1432/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2009});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1433/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2097});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1434/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2373});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1435/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2471});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1436/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2482});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1437/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2725});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1438/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2849});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1439/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2862});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1440/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2889});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1441/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2910});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1442/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2912});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1443/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2928});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1444/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2931});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1445/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2938});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1446/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2969});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1447/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2970});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1448/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2971});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1449/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2973});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1450/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2985});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1451/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy2987});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1452/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3006});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1453/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3009});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1454/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3014});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1455/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3015});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1456/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3020});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1457/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3021});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1458/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3022});
-                }
-                else if (url === 'http://localhost:8081/dinghyracing/api/entries/1459/dinghy') {
-                    return Promise.resolve({'success': true, 'domainObject': dinghy3088});
-                }
-                else {
-                    return Promise.resolve({'success': false, 'message': 'Unable to identify dinghy.'});
-                }
-            });
-            jest.spyOn(dinghyRacingModel, 'getDinghyClass').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': dinghyClassGraduate})});
-            jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
             const promise = dinghyRacingModel.getEntriesByRace(raceGraduateA);
             const result = await promise;
             expect(promise).toBeInstanceOf(Promise);

--- a/src/model/dinghy-racing-model.test.js
+++ b/src/model/dinghy-racing-model.test.js
@@ -54,6 +54,8 @@ global.fetch = jest.fn();
 
 beforeEach(() => {
     fetch.mockClear();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
 });
 
 describe('when creating a new object via REST', () => {
@@ -1088,7 +1090,7 @@ describe('when signing up to a race', () => {
         const promise = dinghyRacingModel.createEntry(raceScorpionA, competitorChrisMarshall, dinghy1234, competitorLouScrew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
-        expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
+        expect(result).toEqual({success: true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if race exists and URL provided helm exists and URL provided and dinghy exist and URL provided and crew not provided then creates race entry', async () => {
         fetch.mockImplementationOnce((resource, options) => {
@@ -1116,6 +1118,7 @@ describe('when signing up to a race', () => {
         const promise = dinghyRacingModel.createEntry(raceScorpionA, competitorChrisMarshall, dinghy1234);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if race exists and name and planned start time provided and helm exists and name provided and dinghy exists and sail number and class provided and crew exists and name provided then creates race entry', async () => {
@@ -1162,6 +1165,7 @@ describe('when signing up to a race', () => {
         const promise = dinghyRacingModel.createEntry(race, helm, dinghy, crew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if race exists and name and planned start time provided and helm exists and name provided and dinghy exists and sail number and class provided and crew not provided then creates race entry', async () => {
@@ -1204,6 +1208,7 @@ describe('when signing up to a race', () => {
         const promise = dinghyRacingModel.createEntry(race, helm, dinghy);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('race does not exist helm exists and URL provided dinghy exists and sail number and class provided crew exists and URL provided then does not create entry and provides message indicating cause of failure', async () => {
@@ -1425,6 +1430,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, competitorChrisMarshall, dinghy1234, competitorLouScrew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if entry exists and URL provided helm exists and URL provided and dinghy exists and URL provided and crew not provided then updates entry', async () => {
@@ -1455,6 +1461,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, competitorChrisMarshall, dinghy1234);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if entry exists and URL provided and helm exists and name provided and dinghy exists and sail number and class provided and crew exists and name provided then updates entry', async () => {
@@ -1499,6 +1506,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, helm, dinghy, crew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('if entry exists url provided and helm exists and name provided and dinghy exists and sail number and class provided and crew not provided then updates entry', async () => {
@@ -1540,6 +1548,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, helm, dinghy);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': true, domainObject: entryChrisMarshallScorpionA1234});
     });
     it('entry exists url provided helm does not exist dinghy exists url provided crew exists and name provided does not update entry and returns message explaining reason', async () => {
@@ -1572,6 +1581,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, helm, dinghy, crew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'Competitor not found'});
     });
     it('entry exists and helm exists and name provided dinghy does not exists crew exists and name provided does not update entry and returns message explaining reason', async () => {
@@ -1606,6 +1616,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, helm, dinghy, crew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'Dinghy does not exist'});
     });
     it('entry exists url provided helm exists url provided, dinghy exists sail number and class provided crew does not exist does not update entry and returns message explaining reason', async () => {
@@ -1636,6 +1647,7 @@ describe('when updating an entry for a race', () => {
         const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, helm, dinghy, crew);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'Competitor not found: Lucy Liu'});
     });
     describe('when dinghy is already recorded for entry in race', () => {
@@ -1654,6 +1666,7 @@ describe('when updating an entry for a race', () => {
             const promise = dinghyRacingModel.updateEntry(entryChrisMarshallScorpionA1234, competitorChrisMarshall, dinghy1234, competitorLouScrew);
             const result = await promise;
             expect(promise).toBeInstanceOf(Promise);
+            // let temp = {...entryChrisMarshallScorpionA1234};
             expect(result).toEqual({'success': false, message: 'A race entry already exists for the selected dinghy.'});
         });
     });
@@ -1720,6 +1733,7 @@ describe('when withdrawing an entry for a race', () => {
         const promise = dinghyRacingModel.withdrawEntry(entryChrisMarshallScorpionA1234);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result.success).toBeTruthy();
     });
     it('returns a promise resolvig to a failure result and containing a message describibg the cause of the failure when unable to withdraw', async () => {
@@ -1735,6 +1749,7 @@ describe('when withdrawing an entry for a race', () => {
         const promise = dinghyRacingModel.delete(entryChrisMarshallScorpionA1234);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'HTTP Error: 404 Not Found'});
     });
 });
@@ -4230,9 +4245,10 @@ describe('when adding a lap to a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.addLap(entryChrisMarshallScorpionA1234, 1000);
+        const promise = dinghyRacingModel.addLap({...entryChrisMarshallScorpionA1234}, 1000);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result.success).toBeTruthy();
     });
     it('returns a promise that resolves to a result indicating failure when lap is rejected by REST service', async () => {
@@ -4245,9 +4261,10 @@ describe('when adding a lap to a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.addLap(entryChrisMarshallScorpionA1234, 1000);
+        const promise = dinghyRacingModel.addLap({...entryChrisMarshallScorpionA1234}, 1000);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'HTTP Error: 404 Not Found'});
     });
 });
@@ -4262,9 +4279,10 @@ describe('when removing a lap from a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.removeLap(entryChrisMarshallScorpionA1234, {...DinghyRacingModel.lapTemplate(),'number': 1, 'time': 1000});
+        const promise = dinghyRacingModel.removeLap({...entryChrisMarshallScorpionA1234}, {...DinghyRacingModel.lapTemplate(),'number': 1, 'time': 1000});
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result.success).toBeTruthy();
     });
     it('returns a promise that resolves to a result indicating failure when lap removal is rejected by REST service', async () => {
@@ -4277,9 +4295,10 @@ describe('when removing a lap from a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.removeLap(entryChrisMarshallScorpionA1234, {...DinghyRacingModel.lapTemplate(),'number': 1, 'time': 1000});
+        const promise = dinghyRacingModel.removeLap({...entryChrisMarshallScorpionA1234}, {...DinghyRacingModel.lapTemplate(),'number': 1, 'time': 1000});
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        // let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'HTTP Error: 404 Not Found'});
     });
 });
@@ -4294,7 +4313,7 @@ describe('when updating a lap from a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.updateLap(entryChrisMarshallScorpionA1234, 2000);
+        const promise = dinghyRacingModel.updateLap({...entryChrisMarshallScorpionA1234}, 2000);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
         expect(result.success).toBeTruthy();
@@ -4309,9 +4328,10 @@ describe('when updating a lap from a race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.updateLap(entryChrisMarshallScorpionA1234, 2000);
+        const promise = dinghyRacingModel.updateLap({...entryChrisMarshallScorpionA1234}, 2000);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'HTTP Error: 404 Not Found'});
     });
 });
@@ -5586,9 +5606,10 @@ describe('when updating an entries position in the race', () => {
             };
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.updateEntryPosition(entryChrisMarshallScorpionA1234, 2);
+        const promise = dinghyRacingModel.updateEntryPosition({...entryChrisMarshallScorpionA1234}, 2);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
         expect(result.success).toBeTruthy();
     });
     it('if race URL not provided and entry exists and URL provided then returns message explaining issue', async () => {
@@ -5596,6 +5617,7 @@ describe('when updating an entries position in the race', () => {
         const promise = dinghyRacingModel.updateEntryPosition({...entryChrisMarshallScorpionA1234, race: {...raceScorpionA, url: null}}, 2);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, message: 'The race URL is required to update an entry position.'});
     });
     it('if race exists and URL provided and entry URL not provided then returns message explaining issue', async () => {
@@ -5603,6 +5625,7 @@ describe('when updating an entries position in the race', () => {
         const promise = dinghyRacingModel.updateEntryPosition({...entryChrisMarshallScorpionA1234, url: ''}, 2);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, message: 'An entry with a URL is required to update an entry position.'});
     });
     it('if update fails returns failed indicator and message explaining cause of failure', async () => {
@@ -5615,9 +5638,55 @@ describe('when updating an entries position in the race', () => {
             });
         });
         const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
-        const promise = dinghyRacingModel.updateEntryPosition(entryChrisMarshallScorpionA1234, 2);
+        const promise = dinghyRacingModel.updateEntryPosition({...entryChrisMarshallScorpionA1234}, 2);
         const result = await promise;
         expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
         expect(result).toEqual({'success': false, 'message': 'HTTP Error: 500 Internal Server Error'});
+    });
+});
+
+describe('when an entry is requested', () => {
+    it('returns a promise that resolves to a result indicating success and containing the entry when the entry is found', async () => {
+        fetch.mockImplementationOnce(() => {
+            return Promise.resolve({
+                ok: true,
+                status: 200, 
+                json: () => Promise.resolve(entryChrisMarshallDinghy1234HAL)
+            });
+        });
+        const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
+        jest.spyOn(dinghyRacingModel, 'getRace').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': raceScorpionA})});
+        jest.spyOn(dinghyRacingModel, 'getCompetitor').mockImplementation((url) => {
+            if (url === 'http://localhost:8081/dinghyracing/api/entries/10/helm') {
+                return Promise.resolve({'success': true, 'domainObject': competitorChrisMarshall});
+            }
+            else if (url === 'http://localhost:8081/dinghyracing/api/entries/10/crew') {
+                return Promise.resolve({'success': true, 'domainObject': competitorLouScrew});
+            }
+        });
+        jest.spyOn(dinghyRacingModel, 'getDinghy').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': dinghy1234})});
+        jest.spyOn(dinghyRacingModel, 'getLaps').mockImplementation(() => {return Promise.resolve({'success': true, 'domainObject': []})});
+        const promise = dinghyRacingModel.getEntry(entryChrisMarshallScorpionA1234.url);
+        const result = await promise;
+        expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
+        expect(result).toEqual({'success': true, 'domainObject': entryChrisMarshallScorpionA1234});
+    });
+    it('returns a promise that resolves to a result indicating failure when entry is not found', async () => {
+        fetch.mockImplementationOnce(() => {
+            return Promise.resolve({
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
+                json: () => Promise.resolve({'cause': {'cause': null, 'message': 'Some error resulting in HTTP 404'}, 'message': 'Some error resulting in HTTP 404'})
+            });
+        });
+        const dinghyRacingModel = new DinghyRacingModel(httpRootURL, wsRootURL);
+        const promise = dinghyRacingModel.getEntry(entryChrisMarshallScorpionA1234.url);
+        const result = await promise;
+        expect(promise).toBeInstanceOf(Promise);
+        let temp = {...entryChrisMarshallScorpionA1234};
+        expect(result).toEqual({'success': false, 'message': 'HTTP Error: 404 Not Found Message: Some error resulting in HTTP 404'});
     });
 });

--- a/src/model/domain-classes/clock.js
+++ b/src/model/domain-classes/clock.js
@@ -15,6 +15,8 @@
  */
 
 class Clock {
+    static _synchOffset = 0;
+
     _startTime
     _performanceTimerStartTime; // when the race is due to start based on the value of performance.now() when clock was initialised
     _dateNowPerformanceNowDiff; // difference between Date.now() and performance.now() on clock initialisation
@@ -49,6 +51,10 @@ class Clock {
         }
         const timeFormat = new Intl.DateTimeFormat('en-GB', formatOptions);
         return (duration < 0 ? '-' : '') + timeFormat.format(d);
+    }
+
+    static synchToTime(time) {
+        this._synchOffset = time.valueOf() - Date.now();
     }
 
     /**
@@ -131,7 +137,7 @@ class Clock {
             this._dateNowPerformanceNowDiff = dNow - pNow;
             this._performanceTimerStartTime =  this._startTime - this._dateNowPerformanceNowDiff;
         }
-        return pNow - this._performanceTimerStartTime;
+        return pNow - this._performanceTimerStartTime + Clock._synchOffset;
     }
     
     /**

--- a/src/model/domain-classes/clock.js
+++ b/src/model/domain-classes/clock.js
@@ -112,7 +112,7 @@ class Clock {
     
     /**
      * Return a time based on the start time of the clock and the elapsed time calculated by the performance timer
-     * This may differ from the time that would be rturned by new Date() or Date.now()
+     * This may differ from the time that would be returned by new Date() or Date.now()
      * @returns {Date}
      */
     getTime() {

--- a/src/model/domain-classes/clock.js
+++ b/src/model/domain-classes/clock.js
@@ -54,7 +54,7 @@ class Clock {
     }
 
     static synchToTime(time) {
-        this._synchOffset = time.valueOf() - Date.now();
+        Clock._synchOffset = time.valueOf() - Date.now();
     }
 
     /**

--- a/src/model/domain-classes/clock.js
+++ b/src/model/domain-classes/clock.js
@@ -57,6 +57,10 @@ class Clock {
         Clock._synchOffset = time.valueOf() - Date.now();
     }
 
+    static now() {
+        return Date.now() + Clock._synchOffset;
+    }
+
     /**
      * Create a new instance of Clock
      * @param {Date} startTime The start time for the clock. Defaults to the time of instantiation.

--- a/src/model/domain-classes/clock.test.js
+++ b/src/model/domain-classes/clock.test.js
@@ -110,6 +110,11 @@ describe('when formatting a duration', () => {
     });
 });
 
+describe('when not synched against an external clocl', () => {
+    it('returns the same value for Clock.now() as Date.now()', () => {
+        expect(Clock.now()).toEqual(Date.now());
+    })
+})
 describe('when need to synch with an external clock accepts a time to synch clocks to and any associated clocks synch to that time when calculating elapsed time', () => {
     it('returns the correct time', () => {
         jest.useFakeTimers().setSystemTime(new Date('2021-10-14T10:10:00Z'));

--- a/src/model/domain-classes/clock.test.js
+++ b/src/model/domain-classes/clock.test.js
@@ -16,6 +16,14 @@
 
 import Clock from './clock';
 
+it('returns the correct time', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2021-10-14T10:10:00Z'));
+    const clock = new Clock(new Date(Date.now() + 10000));
+    const time = clock.getTime().valueOf();
+    const pMod = Date.now() - Math.floor(performance.now());
+    expect(time).toEqual(Math.floor(performance.now() + pMod));
+});
+
 describe('when provided with a start time', () => {
     it('returns the time to elapse to reach start time when start time is ahead of now', () => {
         const clock = new Clock(new Date(Date.now() + 10000));
@@ -103,6 +111,14 @@ describe('when formatting a duration', () => {
 });
 
 describe('when need to synch with an external clock accepts a time to synch clocks to and any associated clocks synch to that time when calculating elapsed time', () => {
+    it('returns the correct time', () => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-10-14T10:10:00Z'));
+        Clock.synchToTime(new Date(Date.now() - 3000)); // set time to synch all clocks to
+        const clock = new Clock(new Date(Date.now() + 10000));
+        const time = clock.getTime().valueOf();
+        const pMod = Date.now() - Math.floor(performance.now());
+        expect(time).toEqual(Math.floor(performance.now() + pMod) - 3000);
+    });
     it('returns the time to elapse to reach start time when start time is ahead of now', () => {
         Clock.synchToTime(new Date(Date.now() - 3000)); // set time to synch all clocks to
         const clock = new Clock(new Date(Date.now() + 10000)); // create a clock

--- a/src/model/domain-classes/clock.test.js
+++ b/src/model/domain-classes/clock.test.js
@@ -21,7 +21,7 @@ describe('when provided with a start time', () => {
         const clock = new Clock(new Date(Date.now() + 10000));
         expect(Math.round(clock.getElapsedTime())).toBe(-10000);
     });
-    it('returns the amount of time elapsed sins the start time when start time is in the past', () => {
+    it('returns the amount of time elapsed since the start time when start time is in the past', () => {
         const clock = new Clock(new Date(Date.now() - 999));
         expect(Math.round(clock.getElapsedTime())).toBe(999);
     });
@@ -34,7 +34,7 @@ describe('when started without providing a start time', () => {
         // sleep thread and then check time is as expected
         setTimeout(() => {
             const elapsed = clock.getElapsedTime();
-        expect(Math.round(elapsed)).toBe(1000);    
+        expect(Math.round(elapsed)).toBe(1000);
         }, 1000);
     });    
 });
@@ -101,3 +101,25 @@ describe('when formatting a duration', () => {
         expect(Clock.formatDuration(-1379000)).toBe('-22:59');
     });
 });
+
+describe('when need to synch with an external clock accepts a time to synch clocks to and any associated clocks synch to that time when calculating elapsed time', () => {
+    it('returns the time to elapse to reach start time when start time is ahead of now', () => {
+        Clock.synchToTime(new Date(Date.now() - 3000)); // set time to synch all clocks to
+        const clock = new Clock(new Date(Date.now() + 10000)); // create a clock
+        expect(Math.round(clock.getElapsedTime())).toBe(-10000 - 3000);
+    });
+    it('returns the amount of time elapsed since the start time when start time is in the past', () => {
+        Clock.synchToTime(new Date(Date.now() - 3000)); // set time to synch all clocks to
+        const clock = new Clock(new Date(Date.now() - 999));
+        expect(Math.round(clock.getElapsedTime())).toBe(999 - 3000);
+    });
+    describe('when more than one clock', () => {
+        it('all clock return adjusted time', () => {
+            Clock.synchToTime(new Date(Date.now() - 3000)); // set time to synch all clocks to
+            const clock1 = new Clock(new Date(Date.now() + 10000)); // create a clock
+            const clock2 = new Clock(new Date(Date.now() + 6000)); // create a clock
+            expect(Math.round(clock1.getElapsedTime())).toBe(-10000 - 3000);
+            expect(Math.round(clock2.getElapsedTime())).toBe(-6000 - 3000);
+        });
+    });
+})

--- a/src/model/domain-classes/clock.test.js
+++ b/src/model/domain-classes/clock.test.js
@@ -114,7 +114,8 @@ describe('when not synched against an external clocl', () => {
     it('returns the same value for Clock.now() as Date.now()', () => {
         expect(Clock.now()).toEqual(Date.now());
     })
-})
+});
+
 describe('when need to synch with an external clock accepts a time to synch clocks to and any associated clocks synch to that time when calculating elapsed time', () => {
     it('returns the correct time', () => {
         jest.useFakeTimers().setSystemTime(new Date('2021-10-14T10:10:00Z'));
@@ -142,5 +143,18 @@ describe('when need to synch with an external clock accepts a time to synch cloc
             expect(Math.round(clock1.getElapsedTime())).toBe(-10000 - 3000);
             expect(Math.round(clock2.getElapsedTime())).toBe(-6000 - 3000);
         });
+    });
+    it('sends message to a broadcast channel to advise either Clocks to synch to external time', () => {
+        const postMessageSpy = jest.spyOn(BroadcastChannel.prototype, 'postMessage');
+        const testTime = new Date();
+        Clock.synchToTime(testTime);
+        expect(postMessageSpy).toBeCalledWith({message: 'synchToTime', body: testTime});
+    });
+    // not sure how to make this work. May need to bring in broadcast-channel package from NPM and use to pollyfill jest. Would then need to create a seperate context to send messages between? :-/
+    xit('picks up a message from a broadcast channel to receive notification to synch against an external time', () => {
+        // const onmessageSpy = jest.spyOn(BroadcastChannel.prototype, 'onmessage');
+        const testTime = new Date(Date.now() + 1000);
+        Clock.synchToTime(testTime);
+        expect(onmessageSpy).toBeCalledWith({message: 'synchToTime', body: testTime});
     });
 })

--- a/src/model/domain-classes/race-start-sequence.js
+++ b/src/model/domain-classes/race-start-sequence.js
@@ -188,7 +188,7 @@ class RaceStartSequence {
                     // set up start signals for subsequent dinghy classes
                     const warningFlag = {name: sortedDinghyClasses[i].name + ' Class Flag', role: FlagRole.WARNING, actions: []};
 
-                    const offset = Math.round((baseDuration - ((baseDuration * sortedDinghyClasses[i].portsmouthNumber) / basePN)) / 1000) * 1000; // round to the nearest second as this is the precision we are working with
+                    const offset = Math.ceil((baseDuration - ((baseDuration * sortedDinghyClasses[i].portsmouthNumber) / basePN)) / 1000) * 1000; // round to the nearest second as this is the precision we are working with
                     
                     const warningFlagRaiseAction = {flag: warningFlag, time: new Date(race.plannedStartTime.valueOf() + offset - 60000), afterState: FlagState.RAISED};
                     const warningFlagLowerAction = {flag: warningFlag, time: new Date(race.plannedStartTime.valueOf() + offset), afterState: FlagState.LOWERED};

--- a/src/model/domain-classes/race-start-sequence.test.js
+++ b/src/model/domain-classes/race-start-sequence.test.js
@@ -384,17 +384,17 @@ describe('when using CSC club start', () => {
     });
     describe('when Pursuit race', () => {
         it('returns flags', () => {
-            const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+            const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
             const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
         
             const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, actions: []};
             const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, actions: []};
-            const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, actions: []};
+            const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, actions: []};
             const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, actions: []};
             const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
             const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-            const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-            const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+            const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+            const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
             const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
             const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
             const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -415,17 +415,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 11 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -445,17 +445,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -483,17 +483,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 10 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -513,17 +513,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -551,17 +551,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 5 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.RAISED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -581,17 +581,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.RAISED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -619,17 +619,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 0 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -649,17 +649,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -685,19 +685,19 @@ describe('when using CSC club start', () => {
                 expect(flags[3]).toStrictEqual({flag: laserWarningFlag, action: laserWarningFlagRaiseAction});
             });
         });
-        describe('when 9 minutes after the start of the race', () => {
+        describe('when 11 minutes after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -712,22 +712,22 @@ describe('when using CSC club start', () => {
                 preparatoryFlag.actions.push(preparatoryFlagRaiseAction);
                 preparatoryFlag.actions.push(preparatoryFlagLowerAction);
                 
-                const flags = raceStartSequence.getFlagsAtTime(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 540000));
+                const flags = raceStartSequence.getFlagsAtTime(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 660000));
     
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -742,7 +742,7 @@ describe('when using CSC club start', () => {
                 preparatoryFlag.actions.push(preparatoryFlagRaiseAction);
                 preparatoryFlag.actions.push(preparatoryFlagLowerAction);
                 
-                const flags = raceStartSequence.getFlagsAtTimeWithNextAction(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 540000));
+                const flags = raceStartSequence.getFlagsAtTimeWithNextAction(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 660000));
     
                 expect(flags).toHaveLength(4);
                 expect(flags[0].flag).toStrictEqual(baseWarningFlag);
@@ -755,17 +755,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 17 minutes after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -785,17 +785,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -823,17 +823,17 @@ describe('when using CSC club start', () => {
         });
         describe('when 17 minutes 55 seconds after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -853,17 +853,17 @@ describe('when using CSC club start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.CSCCLUBSTART};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 600000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
@@ -1326,17 +1326,17 @@ describe('when using RRS26 start', () => {
     });
     describe('when Pursuit race', () => {
         it('returns flags', () => {
-            const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+            const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
             const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
         
             const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, actions: []};
             const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, actions: []};
-            const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, actions: []};
+            const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, actions: []};
             const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, actions: []};
             const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
             const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-            const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-            const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+            const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+            const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
             const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
             const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
             const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1357,17 +1357,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 6 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1387,17 +1387,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1425,17 +1425,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 5 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1455,17 +1455,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1493,17 +1493,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 4 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.RAISED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1523,17 +1523,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.RAISED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1561,17 +1561,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 1 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1591,17 +1591,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1629,17 +1629,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 0 minutes before the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1659,17 +1659,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1695,19 +1695,19 @@ describe('when using RRS26 start', () => {
                 expect(flags[3]).toStrictEqual({flag: laserWarningFlag, action: laserWarningFlagRaiseAction});
             });
         });
-        describe('when 9 minutes after the start of the race', () => {
+        describe('when 11 minutes after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1722,22 +1722,22 @@ describe('when using RRS26 start', () => {
                 preparatoryFlag.actions.push(preparatoryFlagRaiseAction);
                 preparatoryFlag.actions.push(preparatoryFlagLowerAction);
                 
-                const flags = raceStartSequence.getFlagsAtTime(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 540000));
+                const flags = raceStartSequence.getFlagsAtTime(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 660000));
     
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1752,7 +1752,7 @@ describe('when using RRS26 start', () => {
                 preparatoryFlag.actions.push(preparatoryFlagRaiseAction);
                 preparatoryFlag.actions.push(preparatoryFlagLowerAction);
                 
-                const flags = raceStartSequence.getFlagsAtTimeWithNextAction(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 540000));
+                const flags = raceStartSequence.getFlagsAtTimeWithNextAction(new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 660000));
     
                 expect(flags).toHaveLength(4);
                 expect(flags[0].flag).toStrictEqual(baseWarningFlag);
@@ -1765,17 +1765,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 17 minutes after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1795,17 +1795,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.RAISED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1833,17 +1833,17 @@ describe('when using RRS26 start', () => {
         });
         describe('when 17 minutes 55 seconds after the start of the race', () => {
             it('returns correct flags', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};
@@ -1863,17 +1863,17 @@ describe('when using RRS26 start', () => {
                 expect(flags).toEqual([baseWarningFlag, preparatoryFlag, topperWarningFlag, laserWarningFlag]);
             });
             it('returns correct flags with correct next action', () => {
-                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper 4.2', crewSize: 1, portsmouthNumber: 1425}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
+                const raceWithDinghyClasses = {...racePursuitA, dinghyClasses: [{name: 'Topper', crewSize: 1, portsmouthNumber: 1369}, {name: 'Laser', crewSize: 1, portsmouthNumber: 1102}], startType: StartType.RRS26};
                 const raceStartSequence = new RaceStartSequence(raceWithDinghyClasses);
             
                 const baseWarningFlag = {name: 'Optimist (Club) Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const preparatoryFlag = {name: 'Blue Peter', role: FlagRole.PREPARATORY, state: FlagState.LOWERED, actions: []};
-                const topperWarningFlag = {name: 'Topper 4.2 Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
+                const topperWarningFlag = {name: 'Topper Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const laserWarningFlag = {name: 'Laser Class Flag', role: FlagRole.WARNING, state: FlagState.LOWERED, actions: []};
                 const baseWarningFlagRaiseAction = {flag: baseWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 300000), afterState: FlagState.RAISED};
                 const baseWarningFlagLowerAction = {flag: baseWarningFlag, time: raceWithDinghyClasses.plannedStartTime, afterState: FlagState.LOWERED};
-                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 599000), afterState: FlagState.RAISED};
-                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 599000), afterState: FlagState.LOWERED};
+                const topperWarningFlagRaiseAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 682000), afterState: FlagState.RAISED};
+                const topperWarningFlagLowerAction = {flag: topperWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 682000), afterState: FlagState.LOWERED};
                 const laserWarningFlagRaiseAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 60000 + 1075000), afterState: FlagState.RAISED};
                 const laserWarningFlagLowerAction = {flag: laserWarningFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() + 1075000), afterState: FlagState.LOWERED};
                 const preparatoryFlagRaiseAction = {flag: preparatoryFlag, time: new Date(raceWithDinghyClasses.plannedStartTime.valueOf() - 240000), afterState: FlagState.RAISED};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -10,18 +10,11 @@ class BroadcastChannel {
 
     constructor(name) {
         this.name = name;
-        // this.onmessage = this.onmessage.bind(this);
     }
 
-    // postMessage = jest.fn();
     postMessage(message) { 
         this.onmessage({data: {message: message}});
     }
-
-    // onmessage = jest.fn();
-    // onmessage(event) {
-    //     return null;
-    // }
 }
 
 if(!global.BroadcastChannel) {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,27 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+class BroadcastChannel {
+    name;
+    onmessage;
+
+    constructor(name) {
+        this.name = name;
+        // this.onmessage = this.onmessage.bind(this);
+    }
+
+    // postMessage = jest.fn();
+    postMessage(message) { 
+        this.onmessage({data: {message: message}});
+    }
+
+    // onmessage = jest.fn();
+    // onmessage(event) {
+    //     return null;
+    // }
+}
+
+if(!global.BroadcastChannel) {
+    global.BroadcastChannel = BroadcastChannel;
+}

--- a/src/view/ActionListView.js
+++ b/src/view/ActionListView.js
@@ -27,7 +27,7 @@ import { sortArray } from '../utilities/array-utilities';
  */
 function ActionListView({ actions }) {
     const [clock] = useState(new Clock(Date.now()));
-    const [time, setTime] = useState(Clock.now());
+    const [time, setTime] = useState(Clock.now()); // use Clock.now to get adjusted time when synched to an external clock
 
     function handleTick() {
         setTime(Clock.now());

--- a/src/view/ActionListView.js
+++ b/src/view/ActionListView.js
@@ -27,10 +27,10 @@ import { sortArray } from '../utilities/array-utilities';
  */
 function ActionListView({ actions }) {
     const [clock] = useState(new Clock(Date.now()));
-    const [time, setTime] = useState(new Date());
+    const [time, setTime] = useState(Clock.now());
 
     function handleTick() {
-        setTime(new Date());
+        setTime(Clock.now());
     };
 
     useEffect(() => {

--- a/src/view/LapView.js
+++ b/src/view/LapView.js
@@ -36,7 +36,7 @@ function LapView({value, total, editable = false, keyup, focusout}) {
 
     const [editValue, setEditValue] = useState(Clock.formatDuration(value));
     const textInputRef = useRef(null);
-    const inner = <input ref={textInputRef} type='text' value={editValue} onChange={handleChange} onKeyUp={keyup} onBlur={focusout}/>;
+    // const inner = <input ref={textInputRef} type='text' value={editValue} onChange={handleChange} onKeyUp={keyup} onBlur={focusout}/>;
     const classes = total ? 'total' : null;
 
     useEffect(() => {
@@ -46,7 +46,10 @@ function LapView({value, total, editable = false, keyup, focusout}) {
     });
 
     return (
-        editable ? <td className={classes} >{inner}</td> : <td className={classes} >{Clock.formatDuration(value)}</td>
+        // editable ? <td className={classes} >{inner}</td> : <td className={classes} >{Clock.formatDuration(value)}</td>
+        <div className="race-entry-view-container race-entry-view-border">
+            {editable ? <input ref={textInputRef} className={classes} type='text' value={editValue} onChange={handleChange} onKeyUp={keyup} onBlur={focusout}/> : <output className={classes} >{Clock.formatDuration(value)}</output>}
+        </div>
     );
 }
 

--- a/src/view/LapView.test.js
+++ b/src/view/LapView.test.js
@@ -20,15 +20,13 @@ import LapView from './LapView';
 
 describe('when editable is false', () => {
     it('displays value in time format', () => {
-        const container = document.createElement('tr');
-        render(<LapView value={1015897} />, {'container': document.body.appendChild(container)});
+        render(<LapView value={1015897} />);
         screen.getByText('16:56');
     });
     it('does not call value passed to keyup', async () => {
         const keyupMock = jest.fn();
-        const user = userEvent.setup(); 
-        const container = document.createElement('tr');
-        render(<LapView value={895689} editable={false} keyup={keyupMock} />, {'container': document.body.appendChild(container)});
+        const user = userEvent.setup();
+        render(<LapView value={895689} editable={false} keyup={keyupMock} />);
         screen.getByText('14:56').focus();
         await user.keyboard('{Enter}');
         expect(keyupMock).not.toBeCalled();
@@ -37,8 +35,7 @@ describe('when editable is false', () => {
         const keyupMock = jest.fn();
         const focusoutMock = jest.fn();
         const user = userEvent.setup(); 
-        const container = document.createElement('tr');
-        render(<LapView value={312568} editable={false} keyup={keyupMock} focusout={focusoutMock} />, {'container': document.body.appendChild(container)});
+        render(<LapView value={312568} editable={false} keyup={keyupMock} focusout={focusoutMock} />);
         const cell = screen.getByText('05:13');
         cell.focus();
         cell.blur();
@@ -46,8 +43,7 @@ describe('when editable is false', () => {
     });
     describe('when cell contains a total', () => {
         it('has class total', () => {
-            const container = document.createElement('tr');
-            render(<LapView value={1015897} total={true} />, {'container': document.body.appendChild(container)});
+            render(<LapView value={1015897} total={true} />);
             expect(screen.getByText('16:56').getAttribute('class')).toMatch(/total/i);
         });
     });
@@ -55,14 +51,12 @@ describe('when editable is false', () => {
 
 describe('when editable is true', () => {
     it('displays value in time format', () => {
-        const container = document.createElement('tr');
-        render(<LapView value={1234} editable={true}/>, {'container': document.body.appendChild(container)});
+        render(<LapView value={1234} editable={true}/>);
         screen.getByRole('textbox', {'value': '00:01'});
     });
     it('accepts a new value', async () => {
         const user = userEvent.setup();
-        const container = document.createElement('tr');
-        render(<LapView value={1234} editable={true}/>, {'container': document.body.appendChild(container)});
+        render(<LapView value={1234} editable={true}/>);
         const input = screen.getByRole('textbox', {'value': '00:01'});
         await act(async () => {
             await user.clear(input);
@@ -72,9 +66,8 @@ describe('when editable is true', () => {
     }); 
     it('calls value passed to keyup', async () => {
         const keyupMock = jest.fn();
-        const user = userEvent.setup(); 
-        const container = document.createElement('tr');
-        render(<LapView value={1234} editable={true} keyup={keyupMock} />, {'container': document.body.appendChild(container)});
+        const user = userEvent.setup();
+        render(<LapView value={1234} editable={true} keyup={keyupMock} />);
         screen.getByRole('textbox').focus();
         await user.keyboard('{Enter}');
         expect(keyupMock).toBeCalled();
@@ -82,9 +75,8 @@ describe('when editable is true', () => {
     it('calls value passed to focusout', () => {
         const keyupMock = jest.fn();
         const focusoutMock = jest.fn();
-        const user = userEvent.setup(); 
-        const container = document.createElement('tr');
-        render(<LapView value={1234} editable={true} keyup={keyupMock} focusout={focusoutMock} />, {'container': document.body.appendChild(container)});
+        const user = userEvent.setup();
+        render(<LapView value={1234} editable={true} keyup={keyupMock} focusout={focusoutMock} />);
         const cell = screen.getByRole('textbox');
         cell.focus();
         cell.blur();
@@ -93,8 +85,7 @@ describe('when editable is true', () => {
     describe('when validating entry', () => {
         it('does not accept letters', async () => {
             const user = userEvent.setup();
-            const container = document.createElement('tr');
-            render(<LapView value={1234} editable={true}/>, {'container': document.body.appendChild(container)});
+            render(<LapView value={1234} editable={true}/>);
             const input = screen.getByRole('textbox', {'value': '00:01'});
             await act(async () => {
                 await user.clear(input);
@@ -104,8 +95,7 @@ describe('when editable is true', () => {
         });
         it('does not accept 999:63', async () => {
             const user = userEvent.setup();
-            const container = document.createElement('tr');
-            render(<LapView value={1234} editable={true}/>, {'container': document.body.appendChild(container)});
+            render(<LapView value={1234} editable={true}/>);
             const input = screen.getByRole('textbox', {'value': '00:01'});
             await act(async () => {
                 await user.clear(input);
@@ -115,8 +105,7 @@ describe('when editable is true', () => {
         });
         it('does not accept 999:63', async () => {
             const user = userEvent.setup();
-            const container = document.createElement('tr');
-            render(<LapView value={1234} editable={true}/>, {'container': document.body.appendChild(container)});
+            render(<LapView value={1234} editable={true}/>);
             const input = screen.getByRole('textbox', {'value': '00:01'});
             await act(async () => {
                 await user.clear(input);
@@ -127,8 +116,7 @@ describe('when editable is true', () => {
     })
     describe('when cell contains a total', () => {
         it('has class total', () => {
-            const container = document.createElement('tr');
-            render(<LapView value={1015897} total={true} />, {'container': document.body.appendChild(container)});
+            render(<LapView value={1015897} total={true} />);
             expect(screen.getByText('16:56').getAttribute('class')).toMatch(/total/i);
         });
     });

--- a/src/view/RaceConsole.test.js
+++ b/src/view/RaceConsole.test.js
@@ -16,7 +16,7 @@
 
 import { customRender } from '../test-utilities/custom-renders';
 import userEvent from '@testing-library/user-event';
-import { act, screen } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import RaceConsole from './RaceConsole';
 import { httpRootURL, wsRootURL, races, entriesScorpionA, entriesGraduateA, raceScorpionA, raceGraduateA } from '../model/__mocks__/test-data';
 import DinghyRacingModel from '../model/dinghy-racing-model';
@@ -261,7 +261,8 @@ describe('when a race is unselected', () => {
             await user.selectOptions(selectRace, ['Scorpion A', 'Graduate A']);
         });
         
-        const graduateEntries = await screen.findAllByRole('rowheader', {'name': /Graduate/i});
+
+        const graduateEntries = await within(document.getElementsByClassName('race-entries-view')[0]).findAllByText(/Graduate/i);
         graduateEntries.forEach(entry => expect(entry).toBeInTheDocument());
         await act(async () => {
             await user.deselectOptions(selectRace, ['Graduate A']);

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -202,6 +202,10 @@ function RaceEntriesView({ races }) {
         }
     }
 
+    function onRaceEntryPositionSetByDrag(entryKey, newPosition) {
+        updateEntryPosition(entriesMap.get(entryKey), newPosition);
+    }
+
     return (
         <div className="race-entries-view" >
             <p id="race-entries-message" className={!message ? "hidden" : ""}>{message}</p>
@@ -214,7 +218,8 @@ function RaceEntriesView({ races }) {
                 <button onClick={() => setSortOrder('position')}>By position</button>
             </div>
             <div className="scrollable">
-                {sorted().map(entry => <RaceEntryView key={entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name} entry={entry} addLap={addLap} removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} updatePosition={updateEntryPosition} />)}
+                {sorted().map(entry => <RaceEntryView key={entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name} entry={entry} addLap={addLap} 
+                    removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} updatePosition={updateEntryPosition} onRaceEntryDrop={onRaceEntryPositionSetByDrag} />)}
             </div>
         </div>
     );

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -176,6 +176,10 @@ function RaceEntriesView({ races }) {
      */
     async function updateEntryPosition(entry, newPosition) {
         let result;
+        if (!newPosition) {
+            setMessage('No position to set');
+            return;
+        }
         switch (newPosition) {
             case PositionConstant.MOVEUPONE:
                 if (entry.position != null) {
@@ -219,7 +223,7 @@ function RaceEntriesView({ races }) {
             </div>
             <div className="scrollable">
                 {sorted().map(entry => <RaceEntryView key={entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name} entry={entry} addLap={addLap} 
-                    removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} updatePosition={updateEntryPosition} onRaceEntryDrop={onRaceEntryPositionSetByDrag} />)}
+                    removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} onRaceEntryDrop={onRaceEntryPositionSetByDrag} />)}
             </div>
         </div>
     );

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -214,11 +214,7 @@ function RaceEntriesView({ races }) {
                 <button onClick={() => setSortOrder('position')}>By position</button>
             </div>
             <div className="scrollable">
-                <table id="race-entries-table" style={{touchAction: 'pinch-zoom pan-y'}}>
-                    <tbody>
-                    {sorted().map(entry => <RaceEntryView key={entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name} entry={entry} addLap={addLap} removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} updatePosition={updateEntryPosition} />)}
-                    </tbody>
-                </table>
+                {sorted().map(entry => <RaceEntryView key={entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name} entry={entry} addLap={addLap} removeLap={removeLap} updateLap={updateLap} setScoringAbbreviation={setScoringAbbreviation} updatePosition={updateEntryPosition} />)}
             </div>
         </div>
     );

--- a/src/view/RaceEntriesView.test.js
+++ b/src/view/RaceEntriesView.test.js
@@ -14,7 +14,7 @@
  * limitations under the License. 
  */
 
-import { act, screen,  } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DinghyRacingModel from '../model/dinghy-racing-model';
 import { customRender } from '../test-utilities/custom-renders';
@@ -38,8 +38,17 @@ it('renders', async () => {
     await act(async () => {
         customRender(<RaceEntriesView races={[raceScorpionA]} />, model);
     });
-    const raceEntries = document.getElementById('race-entries-table');
-    expect(raceEntries).toBeInTheDocument();
+    // const raceEntries = document.getElementById('race-entries-table');
+    // expect(raceEntries).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by sail number/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by class & sail number/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by last 3/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by class & last 3/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by lap times/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by position/i})).toBeInTheDocument();
+    expect(screen.getByText(/1234/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Scorpion/i)[0]).toBeInTheDocument();
+    expect(screen.getByText(/Chris marshaLL/i)).toBeInTheDocument();
 });
 
 it('displays entries for selected races', async () => {
@@ -109,9 +118,10 @@ describe('when sorting entries', () => {
         await act(async () => {
             await user.click(sortBySailNumber);
         });
-        const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-        expect(orderedEntries).toEqual(['1234', '2928', '6745']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/2928/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
     });
     it('sorts by the dinghy class and sail number', async () => {
         const entriesScorpionA = [
@@ -136,10 +146,10 @@ describe('when sorting entries', () => {
         await act(async () => {
             await user.click(sortByClassAndSailNumber);
         });
-        
-        const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-        expect(orderedEntries).toEqual(['2928', '1234', '6745']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/2928/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
     });
     it('sorts by the last three digits of the sail number', async () => {
         const entriesScorpionA = [
@@ -163,9 +173,10 @@ describe('when sorting entries', () => {
         await act(async () => {
             await user.click(sortByLastThreeButton);
         });
-        const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-        expect(orderedEntries).toEqual(['1234', '6745', '2928']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/2928/)).toBeInTheDocument();
     });
     it('sorts by the dinghy class and last three digits of the sail number', async () => {
         const entriesScorpionA = [
@@ -190,10 +201,10 @@ describe('when sorting entries', () => {
         await act(async () => {
             await user.click(sortByClassAndLastThreeButton);
         });
-        
-        const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-        expect(orderedEntries).toEqual(['2928', '1234', '6745']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/2928/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
     });
     it('sorts by the total recorded lap times plus race start time of dinghies in ascending order', async () => {
         const entries = [
@@ -218,10 +229,10 @@ describe('when sorting entries', () => {
         await act(async () => {
             await user.click(sortByLapTimeButton);
         });
-        const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-
-        expect(orderedEntries).toEqual(['1234', '6745', '2928']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/2928/)).toBeInTheDocument();
     });
     it('sorts by position in ascending order', async () => {
         const entries = [
@@ -250,9 +261,15 @@ describe('when sorting entries', () => {
             await user.click(sortByPositionButton);
         });
         // screen.debug();
-        const cells = await screen.findAllByRole('rowheader', {name: /\d{4}/i});
-        const orderedEntries = cells.map(cell => cell.textContent);
-        expect(orderedEntries).toEqual(['1234', '2928', '6745', '9999', '8888']);
+        // const cells = await screen.findAllByRole('rowheader', {name: /\d{4}/i});
+        // const orderedEntries = cells.map(cell => cell.textContent);
+        // expect(orderedEntries).toEqual(['1234', '2928', '6745', '9999', '8888']);
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/2928/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
+        expect(within(raceEntryViews[3]).getByText(/9999/)).toBeInTheDocument();
+        expect(within(raceEntryViews[4]).getByText(/8888/)).toBeInTheDocument();
     });
     describe('when sorting entries that include an entry that did not start', () => {
         it('sorts by the total recorded lap times of dinghies in ascending order except for DNS entry which is placed last', async () => {
@@ -269,10 +286,13 @@ describe('when sorting entries', () => {
             await act(async () => {
                 await user.click(sortByLapTimeButton);
             });
-            const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-            const orderedEntries = cells.map(cell => cell.textContent);
+            // const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
+            // const orderedEntries = cells.map(cell => cell.textContent);
 
-            expect(orderedEntries).toEqual(['6745', '1234']);
+            // expect(orderedEntries).toEqual(['6745', '1234']);
+            const raceEntryViews = document.getElementsByClassName('race-entry-view');
+            expect(within(raceEntryViews[0]).getByText(/6745/)).toBeInTheDocument();
+            expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
         });
     });
     describe('when sorting entries that include an entry that retired', () => {
@@ -292,10 +312,13 @@ describe('when sorting entries', () => {
             await act(async () => {
                 await user.click(sortByLapTimeButton);
             });
-            const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
-            const orderedEntries = cells.map(cell => cell.textContent);
+            // const cells = await screen.findAllByRole('rowheader', {name: /\d+/i});
+            // const orderedEntries = cells.map(cell => cell.textContent);
 
-            expect(orderedEntries).toEqual(['6745', '1234']);
+            // expect(orderedEntries).toEqual(['6745', '1234']);
+            const raceEntryViews = document.getElementsByClassName('race-entry-view');
+            expect(within(raceEntryViews[0]).getByText(/6745/)).toBeInTheDocument();
+            expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
         });
     });
     describe('when sorting entries that include an entry that has been disqualified', () => {
@@ -315,10 +338,13 @@ describe('when sorting entries', () => {
             await act(async () => {
                 await user.click(sortByLapTimeButton);
             });
-            const cells = await screen.findAllByRole('rowheader', {name:/\d+/i});
-            const orderedEntries = cells.map(cell => cell.textContent);
+            // const cells = await screen.findAllByRole('rowheader', {name:/\d+/i});
+            // const orderedEntries = cells.map(cell => cell.textContent);
 
-            expect(orderedEntries).toEqual(['6745', '1234']);
+            // expect(orderedEntries).toEqual(['6745', '1234']);
+            const raceEntryViews = document.getElementsByClassName('race-entry-view');
+            expect(within(raceEntryViews[0]).getByText(/6745/)).toBeInTheDocument();
+            expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
         });
     });
     describe('when sorting entries that include an entry that has finished the race', () => {
@@ -336,10 +362,13 @@ describe('when sorting entries', () => {
             await act(async () => {
                 await user.click(sortByLapTimeButton);
             });
-            const cells = await screen.findAllByRole('rowheader', {'name': /\d{4}/i});
-            const orderedEntries = cells.map(cell => cell.textContent);
+            // const cells = await screen.findAllByRole('rowheader', {'name': /\d{4}/i});
+            // const orderedEntries = cells.map(cell => cell.textContent);
 
-            expect(orderedEntries).toEqual(['1234', '6745']);
+            // expect(orderedEntries).toEqual(['1234', '6745']);
+            const raceEntryViews = document.getElementsByClassName('race-entry-view');
+            expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+            expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
         });
     });
 });
@@ -404,11 +433,12 @@ describe('when adding a lap time', () => {
         });
                
         const entry = await screen.findByText(/1234/i);
+        
+        expect(await screen.queryByText('10:25')).not.toBeInTheDocument();
         await act(async () => {
             model.handleEntryUpdate({'body': entriesScorpionA[0].url});
         });
-        expect(await screen.findByRole('cell', {'name': '05:13'})).toBeInTheDocument();
-        expect(await screen.findByRole('cell', {'name': '10:25'})).toBeInTheDocument();
+        expect(await screen.findByText('10:25')).toBeInTheDocument();
     });
     it('displays a message if there is a problem adding the lap time', async () => {
         const entriesScorpionAPost = [{'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 312568}], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},{'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [],'url': 'http://localhost:8081/dinghyracing/api/entries/11'}];
@@ -497,14 +527,14 @@ describe('when removing a lap time', () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
         const entry = await screen.findByText(/1234/i);
-        const cell = await screen.findByRole('cell', {'name': '05:13'});
-        expect(cell).toBeInTheDocument();
+        const lapTime = await screen.findByText('05:13');
+        expect(lapTime).toBeInTheDocument();
         await act(async ()=> {
             await user.keyboard('{Control>}');
             await user.click(entry);
             model.handleEntryUpdate({'body': entriesScorpionA[0].url});
         });
-        expect(cell).not.toBeInTheDocument();
+        expect(lapTime).not.toBeInTheDocument();
     });
     it('displays a message if there is a problem removing the lap time', async () => {
         const entriesScorpionAPre = [
@@ -573,7 +603,7 @@ describe('when removing a lap time', () => {
 
 describe('when updating a lap time', () => {
     it('updates model', async () => {
-        const entryChrisMarshallScorpionA1234Pre = {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7}], 'sumOfLapTimes': 7, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'};
+        const entryChrisMarshallScorpionA1234Pre = {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7000}], 'sumOfLapTimes': 7000, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'};
         const entriesScorpionAPre = [
             entryChrisMarshallScorpionA1234Pre, 
             {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0,'url': 'http://localhost:8081/dinghyracing/api/entries/11'}
@@ -587,16 +617,17 @@ describe('when updating a lap time', () => {
         await act(async () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        const lapEntryCellOutput = within(raceEntryView).getByText('00:07');
         // render updated components
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         // after render perform update
+        const lapEntryCellInput = within(raceEntryView).getByRole('textbox', {value: '00:07'});
         await act(async () => {
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15:23');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '15:23');
             await user.keyboard('{Enter}');
         });
         expect(updateLapSpy).toBeCalledWith(entryChrisMarshallScorpionA1234Pre, '15:23');
@@ -620,28 +651,29 @@ describe('when updating a lap time', () => {
         await act(async () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        const lapEntryCellOutput = within(raceEntryView).getByText('00:14');
         // render updated components
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         // after render perform update
+        const lapEntryCellInput = within(raceEntryView).getByRole('textbox', {value: '00:14'});
         await act(async () => { 
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15000');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '15000');
             await user.keyboard('{Enter}');
             model.handleEntryUpdate({'body': entriesScorpionA[0].url});
         });
-        expect(await screen.findByRole('cell', {'name': '00:15'})).toBeInTheDocument();
+        expect(await within(raceEntryView).findByText('00:15')).toBeInTheDocument();
     });
     it('displays a message if there is a problem updating the lap time', async () => {
         const entriesScorpionAPre = [
-            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7}], 'sumOfLapTimes': 7, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
+            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7000}], 'sumOfLapTimes': 7000, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
             {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/11'}
         ];
         const entriesScorpionAPost = [
-            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 312568}], 'sumOfLapTimes': 312568, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
+            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 15000}], 'sumOfLapTimes': 15000, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
             {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/11'}
         ];
         const user = userEvent.setup();
@@ -654,22 +686,23 @@ describe('when updating a lap time', () => {
         await act(async () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        const lapEntryCellOutput = within(raceEntryView).getByText('00:07');
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         // after render perform update
+        const lapEntryCellInput = within(raceEntryView).getByRole('textbox', {value: '00:07'});
         await act(async () => { 
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15678');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '00:15');
             await user.keyboard('{Enter}');
         });
         expect(await screen.findByText(/oops/i)).toBeInTheDocument();
     });
     it('clears error message on success', async () => {
         const entriesScorpionAPre = [
-            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7}], 'sumOfLapTimes': 7, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
+            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 7000}], 'sumOfLapTimes': 7000, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
             {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0,'url': 'http://localhost:8081/dinghyracing/api/entries/11'}];
         const entriesScorpionAPost = [
             {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [{'number': 1, 'time': 312568}], 'sumOfLapTimes': 312568, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'},
@@ -685,26 +718,28 @@ describe('when updating a lap time', () => {
         await act(async () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        let raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        let lapEntryCellOutput = within(raceEntryView).getByText('00:07');
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         // after render perform update
+        let lapEntryCellInput = within(raceEntryView).getByRole('textbox', {value: '00:07'});
         await act(async () => { 
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15678');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '00:15');
             await user.keyboard('{Enter}');
         });
         expect(await screen.findByText(/oops/i)).toBeInTheDocument();
-
+        
+        raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        lapEntryCellOutput = within(raceEntryView).getByText('00:07');
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         // after render perform update
+        lapEntryCellInput = within(raceEntryView).getByRole('textbox', {value: '00:15'});
         await act(async () => { 
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15678');
             await user.keyboard('{Enter}');
             model.handleEntryUpdate({'body': entriesScorpionA[0].url});
         });

--- a/src/view/RaceEntryView.js
+++ b/src/view/RaceEntryView.js
@@ -236,18 +236,32 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     }
 
     return (
-        <tr className={classes} onClick={handleClick} onAuxClick={handleAuxClick} onContextMenu={handleContextMenu}
+        <div className={classes} onClick={handleClick} onAuxClick={handleAuxClick} onContextMenu={handleContextMenu}
             onPointerDown={gestureStart} onPointerMove={gestureMove} onPointerUp={gestureEnd} onPointerOut={gestureEnd}
             onPointerLeave={gestureEnd} onPointerCancel={gestureCancel} >
-            <th scope='row'>{entry.dinghy.dinghyClass.name}</th>
-            <th className='sail-number' scope='row'>{entry.dinghy.sailNumber}</th>
-            <th scope='row'>{entry.helm.name}</th>
-            <th scope='row'>{entry.position}</th>
-            {lapsView}
-            <ScoringAbbreviation key={entry.scoringAbbreviation} value={entry.scoringAbbreviation} onChange={handleScoringAbbreviationSelection} />
-            <td><button type="button" onClick={handlePositionUpClick}>Position Up</button></td>
-            <td><button type="button" onClick={handlePositionDownClick}>Position Down</button></td>
-        </tr>
+            <div className="race-entry-view-container race-entry-view-border">
+                <output>{entry.dinghy.dinghyClass.name}</output>
+            </div>
+            <div className="race-entry-view-container race-entry-view-border">
+                <output className='sail-number'>{entry.dinghy.sailNumber}</output>
+            </div>
+            <div className="race-entry-view-container race-entry-view-border">
+                <output>{entry.helm.name}</output>
+            </div>
+            <div className="race-entry-view-container race-entry-view-border">
+                <output id={entry.dinghy.dinghyClass.name + '-' + entry.dinghy.sailNumber + '-' + entry.helm.name + '-position'}>{entry.position}</output>
+            </div>
+            <div className="race-entry-view-laps">
+                {lapsView}
+            </div>
+            <div className="race-entry-view-container">
+                <ScoringAbbreviation key={entry.scoringAbbreviation} value={entry.scoringAbbreviation} onChange={handleScoringAbbreviationSelection} />
+            </div>
+            <div className="entry-buttons">
+                <button type="button" onClick={handlePositionUpClick}>Position Up</button>
+                <button type="button" onClick={handlePositionDownClick}>Position Down</button>
+            </div>
+        </div>
     )
 }
 

--- a/src/view/RaceEntryView.js
+++ b/src/view/RaceEntryView.js
@@ -26,10 +26,10 @@ import { PositionConstant } from './RaceEntriesView';
  * @param {function} props.removeLap
  * @param {function} props.updateLap
  * @param {function} props.setScoringAbbreviation
- * @param {function} props.updatePosition
+ * @param {function} props.onRaceEntryDrop
  * @returns {HTMLTableRowElement}
  */
-function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviation, updatePosition, onRaceEntryDrop}) {
+function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviation, onRaceEntryDrop}) {
     const [editMode, setEditMode] = useState(false);
     const [disabled, setDisabled] = useState(false);
     const prevLapCount = useRef(entry.laps.length);
@@ -93,34 +93,6 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     // disable context menu
     function handleContextMenu(event) {
         event.preventDefault();
-    }
-
-    function handlePositionUpClick(event) {
-        event.stopPropagation();
-        event.preventDefault();
-        if (updatePosition) {
-            setDisabled(true);
-            if (entry.position == null ) {
-                updatePosition(entry, PositionConstant.MOVEUPONE);    
-            }
-            else {
-                updatePosition(entry, entry.position - 1);
-            }
-        }
-    }
-
-    function handlePositionDownClick(event) {
-        event.stopPropagation();
-        event.preventDefault();
-        if (updatePosition) {
-            setDisabled(true);
-            if (entry.position == null ) {
-                updatePosition(entry, PositionConstant.MOVEDOWNONE);    
-            }
-            else {
-                updatePosition(entry, entry.position + 1);
-            }
-        }
     }
 
     function gestureStart(event) {
@@ -273,10 +245,6 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
             </div>
             <div className="race-entry-view-container">
                 <ScoringAbbreviation key={entry.scoringAbbreviation} value={entry.scoringAbbreviation} onChange={handleScoringAbbreviationSelection} />
-            </div>
-            <div className="entry-buttons">
-                <button type="button" onClick={handlePositionUpClick}>Position Up</button>
-                <button type="button" onClick={handlePositionDownClick}>Position Down</button>
             </div>
         </div>
     )

--- a/src/view/RaceEntryView.js
+++ b/src/view/RaceEntryView.js
@@ -29,7 +29,7 @@ import { PositionConstant } from './RaceEntriesView';
  * @param {function} props.updatePosition
  * @returns {HTMLTableRowElement}
  */
-function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviation, updatePosition}) {
+function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviation, updatePosition, onRaceEntryDrop}) {
     const [editMode, setEditMode] = useState(false);
     const [disabled, setDisabled] = useState(false);
     const prevLapCount = useRef(entry.laps.length);
@@ -192,6 +192,23 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
         }
     }
 
+    function dragStartHandler(event) {
+        event.dataTransfer.setData('text/html', entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name);
+        event.dataTransfer.dropEffect = 'move';
+    }
+
+    function dragOverHandler(event) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+    }
+
+    function dropHandler(event) {
+        event.preventDefault();
+        if (onRaceEntryDrop) {
+            onRaceEntryDrop(event.dataTransfer.getData('text/html'), entry.position);
+        }
+    }
+
     let cumulativeLapTimes = 0;
     for (let i = 0; i < entry.laps.length; i++) {
         const lap = entry.laps[i];
@@ -238,7 +255,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     return (
         <div className={classes} onClick={handleClick} onAuxClick={handleAuxClick} onContextMenu={handleContextMenu}
             onPointerDown={gestureStart} onPointerMove={gestureMove} onPointerUp={gestureEnd} onPointerOut={gestureEnd}
-            onPointerLeave={gestureEnd} onPointerCancel={gestureCancel} >
+            onPointerLeave={gestureEnd} onPointerCancel={gestureCancel} onDragStart={dragStartHandler} onDragOver={dragOverHandler} onDrop={dropHandler} draggable >
             <div className="race-entry-view-container race-entry-view-border">
                 <output>{entry.dinghy.dinghyClass.name}</output>
             </div>

--- a/src/view/RaceEntryView.test.js
+++ b/src/view/RaceEntryView.test.js
@@ -14,7 +14,7 @@
  * limitations under the License. 
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RaceEntryView from './RaceEntryView';
 import { entryChrisMarshallScorpionA1234 } from '../model/__mocks__/test-data';
@@ -34,8 +34,7 @@ afterEach(() => {
 });
 
 it('renders', () => {
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />, {container: document.body.appendChild(tableBody)});
+    render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />);
     const SMScorp1234entry = screen.getByText(/1234/i);
     expect(SMScorp1234entry).toBeInTheDocument();
 });
@@ -43,15 +42,13 @@ it('renders', () => {
 it('displays lap times', async () => {
     const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
     const entry = {...entryChrisMarshallScorpionA1234, laps: [{number: 1, time: 1234}]};
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entry} />, {container: document.body.appendChild(tableBody)});
+    render(<RaceEntryView entry={entry} />);
     expect(screen.getByText('00:01')).toBeInTheDocument();
 });
 
 it('displays cumulative sum of lap times', async () => {
     const entry = {...entryChrisMarshallScorpionA1234, laps: [{number: 1, time: 1234}, {number: 2, time: 1234}, {number: 3, time: 1234}]};
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entry} />, {container: document.body.appendChild(tableBody)});
+    render(<RaceEntryView entry={entry} />);
     expect(screen.getByText('00:01')).toBeInTheDocument();
     expect(screen.getByText('00:02')).toBeInTheDocument();
     expect(screen.getByText('00:04')).toBeInTheDocument();
@@ -59,8 +56,7 @@ it('displays cumulative sum of lap times', async () => {
 
 it('displays position', () => {
     const entry = {...entryChrisMarshallScorpionA1234, laps: [{number: 1, time: 1234}, {number: 2, time: 1234}, {number: 3, time: 1234}], position: 5};
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entry} />, {container: document.body.appendChild(tableBody)});
+    render(<RaceEntryView entry={entry} />);
     expect(screen.getByText('5')).toBeInTheDocument();
 });
 
@@ -69,8 +65,7 @@ describe('before race has started', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, race: {...entryChrisMarshallScorpionA1234.race, plannedStartTime: new Date(Date.now() + 60000)}};
         const addLapCallback = jest.fn((e) => {entry.laps.push({'number': 1, 'time': 1234})});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         await act(async () => {
             await user.click(SMScorp1234entry);
@@ -84,8 +79,7 @@ describe('after race has started', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234};
         const addLapCallback = jest.fn((e) => {entry.laps.push({'number': 1, 'time': 1234})});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         await act(async () => {
             await user.click(SMScorp1234entry);
@@ -94,13 +88,11 @@ describe('after race has started', () => {
     });
 });
 
-
 it('calls removeLap callback with entry', async () => {
     const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
     const entry = {...entryChrisMarshallScorpionA1234};
     const removeLapCallback = jest.fn((e) => {entry.laps.pop()});
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />, {container: document.body.appendChild(tableBody)});
+    render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />);
     const SMScorp1234entry = screen.getByText(/1234/i);
     await act(async () => {
         await user.keyboard('{Control>}');
@@ -113,18 +105,19 @@ it('when secondary mouse button is clicked accepts a new lap time input in the l
     const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
     const entry = {...entryChrisMarshallScorpionA1234, 'laps': [{...DinghyRacingModel.lapTemplate(), number: 1, time: 1000}, {...DinghyRacingModel.lapTemplate(), number: 2, time: 2000}, {...DinghyRacingModel.lapTemplate(), number: 3, time: 3000}], 
         'sumOfLapTimes': 6000};
-    const tableBody = document.createElement('tbody');
-    render(<RaceEntryView entry={entry} />, {container: document.body.appendChild(tableBody)});
-    const entryRow = screen.getByText(/1234/i).parentElement;
-    const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+    render(<RaceEntryView entry={entry} />);
+    const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+    // const lapEntryCellOutput = within(raceEntryView).getByRole('status', {value: {text: '00:06'}}); // want to use this but options does not appear to be working with output element
+    const lapEntryCellOutput = within(raceEntryView).getByText('00:06');
     await act(async () => {
-        await user.pointer({target: lastCell, keys: '[MouseRight]'});
+        await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
     });
+    const lapEntryCellInput = within(raceEntryView).getByRole('textbox', '00:06');
     await act(async () => {
-        await user.clear(lastCell.lastChild);
-        await user.type(lastCell.lastChild, '00:15');
+        await user.clear(lapEntryCellInput);
+        await user.type(lapEntryCellInput, '00:15');
     });
-    expect(lastCell.lastChild).toHaveValue('00:15');
+    expect(lapEntryCellInput).toHaveValue('00:15');
 });
 
 describe('when editing a lap time', () => {
@@ -132,15 +125,14 @@ describe('when editing a lap time', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, 'laps': [{...DinghyRacingModel.lapTemplate(), number: 1, time: 1000}, {...DinghyRacingModel.lapTemplate(), number: 2, time: 2000}, {...DinghyRacingModel.lapTemplate(), number: 3, time: 3000}]};
         const addLapCallback = jest.fn();
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} adLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i);
-        const lastCell = SMScorp1234entry.parentElement.lastChild;
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        const lapEntryCellOutput = within(raceEntryView).getByText('00:06');
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
         await act(async () => {
-            await user.click(SMScorp1234entry);
+            await user.click(raceEntryView);
         });
         expect(addLapCallback).not.toHaveBeenCalled();
     });
@@ -148,8 +140,7 @@ describe('when editing a lap time', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234};
         const removeLapCallback = jest.fn((e) => {entry.laps.pop()});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         const lastCell = SMScorp1234entry.parentElement.lastChild;
         await act(async () => {
@@ -168,17 +159,17 @@ describe('when editing a lap time', () => {
             {...DinghyRacingModel.lapTemplate(), number: 2, time: 2000}, 
             {...DinghyRacingModel.lapTemplate(), number: 3, time: 3000}
         ]};
-        const tableBody = document.createElement('tbody');
         const updateLapCallback = jest.fn((entry, value) => {});
-        render(<RaceEntryView entry={entry} updateLap={updateLapCallback} />, {container: document.body.appendChild(tableBody)});
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        render(<RaceEntryView entry={entry} updateLap={updateLapCallback} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        const lapEntryCellOutput = within(raceEntryView).getByText('00:06');
         await act(async () => {
-            await user.pointer({target: lastCell, keys: '[MouseRight]'});
+            await user.pointer({target: lapEntryCellOutput, keys: '[MouseRight]'});
         });
+        const lapEntryCellInput = within(raceEntryView).getByRole('textbox', '00:06');
         await act(async () => {
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '15:53');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '15:53');
             await user.keyboard('{Enter}');
         });
         expect(updateLapCallback).toBeCalledWith(entry, '15:53');
@@ -190,8 +181,7 @@ describe('when user taps row', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234};
         const addLapCallback = jest.fn((e) => {entry.laps.push({'number': 1, 'time': 1234})});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         await act(async () => {
             await user.pointer([{keys: '[TouchA]', target: SMScorp1234entry}]);
@@ -205,23 +195,21 @@ describe('when user taps and holds on row', () => {
         const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, 'laps': [{...DinghyRacingModel.lapTemplate(), number: 1, time: 1000}, {...DinghyRacingModel.lapTemplate(), number: 2, time: 2000}, {...DinghyRacingModel.lapTemplate(), number: 3, time: 3000}]};
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i);
-        const entryRow = screen.getByText(/1234/i).parentElement;
-        const lastCell = entryRow.children[entryRow.children.length - entryRowLastCellLapTimeCellOffset];
+        render(<RaceEntryView entry={entry} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
         await act(async () => {
-            await user.pointer({target: SMScorp1234entry, keys: '[TouchA>]'});
+            await user.pointer({target: raceEntryView, keys: '[TouchA>]'});
         });
         act(() => {
             jest.advanceTimersByTime(500);
         });
+        const lapEntryCellInput = within(raceEntryView).getByRole('textbox', '00:06');
         await act(async () => {
-            await user.clear(lastCell.lastChild);
-            await user.type(lastCell.lastChild, '00:15');
+            await user.clear(lapEntryCellInput);
+            await user.type(lapEntryCellInput, '00:15');
         });
         // expect(lastCell.lastChild).toHaveValue(15678);
-        expect(lastCell.lastChild).toHaveValue('00:15');
+        expect(lapEntryCellInput).toHaveValue('00:15');
     });
 });
 
@@ -232,8 +220,7 @@ describe('when user swipes left on row', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, 'laps': [{...DinghyRacingModel.lapTemplate(), number: 1, time: 1000}, {...DinghyRacingModel.lapTemplate(), number: 2, time: 2000}, {...DinghyRacingModel.lapTemplate(), number: 3, time: 3000}]};
         const removeLapCallback = jest.fn((e) => {entry.laps.pop()});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} removeLap={removeLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         const position1 = SMScorp1234entry.parentElement.children[3];
         const position2 = SMScorp1234entry.parentElement.children[2];
@@ -248,17 +235,15 @@ describe('when user swipes left on row', () => {
 describe('when entry is on last lap', () => {
     it('has a class of on-last-lap', () => {
         const entryOnLastLap = {...entryChrisMarshallScorpionA1234, 'onLastLap': true};
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryOnLastLap} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-        expect(SMScorp1234entry.getAttribute('class')).toMatch(/on-last-lap/i);
+        render(<RaceEntryView entry={entryOnLastLap} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        expect(raceEntryView.getAttribute('class')).toMatch(/on-last-lap/i);
     });
 });
 
 describe('when entry is not on last lap', () => {
     it('does not have a class of on-last-lap', () => {
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />);
         const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
         expect(SMScorp1234entry.getAttribute('class')).not.toMatch(/on-last-lap/i);
     });
@@ -267,17 +252,15 @@ describe('when entry is not on last lap', () => {
 describe('when entry has finished race', () => {
     it('has a class of finished-race', () => {
         const entryOnLastLap = {...entryChrisMarshallScorpionA1234, 'finishedRace': true};
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryOnLastLap} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-        expect(SMScorp1234entry.getAttribute('class')).toMatch(/finished-race/i);
+        render(<RaceEntryView entry={entryOnLastLap} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        expect(raceEntryView.getAttribute('class')).toMatch(/finished-race/i);
     });
 });
 
 describe('when entry has not finished race', () => {
     it('does not have a class of finished-race', () => {
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />);
         const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
         expect(SMScorp1234entry.getAttribute('class')).not.toMatch(/finished-race/i);
     });
@@ -285,10 +268,9 @@ describe('when entry has not finished race', () => {
 
 describe('when a scoring abbreviation is not selected', () => {
     it('only has a class of race-entry-view', () => {
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-        expect(SMScorp1234entry.getAttribute('class')).toMatch(/^race-entry-view$/i);
+        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+        expect(raceEntryView.getAttribute('class')).toMatch(/^race-entry-view$/i);
     });
 });
 
@@ -296,8 +278,7 @@ describe('when a scoring abbreviation is selected', () => {
     it('calls setScoringAbbreviation callback provided as prop', async () => {
         const setScoringAbbreviationSpy = jest.fn();
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} setScoringAbbreviation={setScoringAbbreviationSpy}/>, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entryChrisMarshallScorpionA1234} setScoringAbbreviation={setScoringAbbreviationSpy}/>);
         const selectSA = screen.getByRole('combobox');
         await user.selectOptions(selectSA, 'DNS');
         expect(setScoringAbbreviationSpy).toHaveBeenCalledWith(entryChrisMarshallScorpionA1234, 'DNS');
@@ -305,28 +286,25 @@ describe('when a scoring abbreviation is selected', () => {
     describe('when entry did not start the race', () => {
         it('has a class of did-not-start', () => {
             const entryDNS = {...entryChrisMarshallScorpionA1234, 'scoringAbbreviation': 'DNS'};
-            const tableBody = document.createElement('tbody');
-            render(<RaceEntryView entry={entryDNS} />, {container: document.body.appendChild(tableBody)});
-            const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-            expect(SMScorp1234entry.getAttribute('class')).toMatch(/did-not-start/i);
+            render(<RaceEntryView entry={entryDNS} />);
+            const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+            expect(raceEntryView.getAttribute('class')).toMatch(/did-not-start/i);
         });
     });
     describe('when entry retired', () => {
         it('has a class of retired', () => {
             const entryRET = {...entryChrisMarshallScorpionA1234, 'scoringAbbreviation': 'RET'};
-            const tableBody = document.createElement('tbody');
-            render(<RaceEntryView entry={entryRET} />, {container: document.body.appendChild(tableBody)});
-            const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-            expect(SMScorp1234entry.getAttribute('class')).toMatch(/retired/i);
+            render(<RaceEntryView entry={entryRET} />);
+            const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+            expect(raceEntryView.getAttribute('class')).toMatch(/retired/i);
         });
     });
     describe('when entry disqualified', () => {
         it('has a class of disqualified', () => {
             const entryRET = {...entryChrisMarshallScorpionA1234, 'scoringAbbreviation': 'DSQ'};
-            const tableBody = document.createElement('tbody');
-            render(<RaceEntryView entry={entryRET} />, {container: document.body.appendChild(tableBody)});
-            const SMScorp1234entry = screen.getByText(/1234/i).parentElement;
-            expect(SMScorp1234entry.getAttribute('class')).toMatch(/disqualified/i);
+            render(<RaceEntryView entry={entryRET} />);
+            const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
+            expect(raceEntryView.getAttribute('class')).toMatch(/disqualified/i);
         });
     });
 });
@@ -336,20 +314,18 @@ describe('when the entry is selected to add a new lap', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234};
         const addLapCallback = jest.fn();
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
-        const SMScorp1234entry = screen.getByText(/1234/i);
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
+        const raceEntryView = screen.getByText(/1234/i).parentElement.parentElement;
         await act(async () => {
-            await user.click(SMScorp1234entry);
+            await user.click(raceEntryView);
         });
-        expect(SMScorp1234entry.parentElement.getAttribute('class')).toMatch(/disabled/i);
+        expect(raceEntryView.getAttribute('class')).toMatch(/disabled/i);
     });
     it('does not accept selection to add a new lap time', async () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234};
         const addLapCallback = jest.fn();
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
         const SMScorp1234entry = screen.getByText(/1234/i);
         await act(async () => {
             await user.click(SMScorp1234entry);
@@ -366,8 +342,7 @@ describe('when the entry is selected to add a new lap', () => {
             const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
             const entry = {...entryChrisMarshallScorpionA1234, laps: []};
             const addLapCallback = jest.fn();
-            const tableBody = document.createElement('tbody');
-            const { rerender } = render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+            const { rerender } = render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
             const SMScorp1234entry = await screen.findByText(/1234/i);
             await act(async () => {
                 await user.click(SMScorp1234entry);
@@ -385,8 +360,7 @@ describe('when the entry is selected to add a new lap', () => {
             const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
             const entry = {...entryChrisMarshallScorpionA1234, laps: []};
             const addLapCallback = jest.fn();
-            const tableBody = document.createElement('tbody');
-            const { rerender } = render(<RaceEntryView entry={entry} addLap={addLapCallback} />, {container: document.body.appendChild(tableBody)});
+            const { rerender } = render(<RaceEntryView entry={entry} addLap={addLapCallback} />);
             const SMScorp1234entry = screen.getByText(/1234/i);
             await act(async () => {
                 await user.click(SMScorp1234entry);
@@ -408,8 +382,7 @@ describe('when move position up button is clicked', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, position: 4};
         const updatePositionSpy = jest.fn((entry, newPosition) => {});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
         const updatePositionButton = screen.getByText(/position up/i);
         await act(async () => {
             await user.click(updatePositionButton);
@@ -420,8 +393,7 @@ describe('when move position up button is clicked', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, position: 4};
         const updatePositionSpy = jest.fn((entry, newPosition) => {});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
         const updatePositionButton = screen.getByText(/position up/i);
         await act(async () => {
             await user.click(updatePositionButton);
@@ -433,8 +405,7 @@ describe('when move position up button is clicked', () => {
             const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
             const entry = {...entryChrisMarshallScorpionA1234};
             const updatePositionSpy = jest.fn((entry, newPosition) => {});
-            const tableBody = document.createElement('tbody');
-            render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+            render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
             const updatePositionButton = screen.getByText(/position up/i);
             await act(async () => {
                 await user.click(updatePositionButton);
@@ -449,8 +420,7 @@ describe('when move position down button is clicked', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, position: 4};
         const updatePositionSpy = jest.fn((entry, newPosition) => {});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
         const updatePositionButton = screen.getByText(/position down/i);
         await act(async () => {
             await user.click(updatePositionButton);
@@ -461,8 +431,7 @@ describe('when move position down button is clicked', () => {
         const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const entry = {...entryChrisMarshallScorpionA1234, position: 4};
         const updatePositionSpy = jest.fn((entry, newPosition) => {});
-        const tableBody = document.createElement('tbody');
-        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+        render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
         const updatePositionButton = screen.getByText(/position down/i);
         await act(async () => {
             await user.click(updatePositionButton);
@@ -474,8 +443,7 @@ describe('when move position down button is clicked', () => {
             const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
             const entry = {...entryChrisMarshallScorpionA1234};
             const updatePositionSpy = jest.fn((entry, newPosition) => {});
-            const tableBody = document.createElement('tbody');
-            render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />, {container: document.body.appendChild(tableBody)});
+            render(<RaceEntryView entry={entry} updatePosition={updatePositionSpy} />);
             const updatePositionButton = screen.getByText(/position down/i);
             await act(async () => {
                 await user.click(updatePositionButton);

--- a/src/view/RaceHeaderView.test.js
+++ b/src/view/RaceHeaderView.test.js
@@ -385,7 +385,7 @@ describe('when start now button clicked', () => {
 
 describe('when shorten course button clicked', () => {
     it('displays shorten course dialog', async () => {
-        const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});;
+        const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
         const model = new DinghyRacingModel(httpRootURL, wsRootURL);
         const controller = new DinghyRacingController(model);
         customRender(<RaceHeaderView race={ {...raceScorpionA, 'plannedStartTime': new Date(Date.now() + 10000), 'clock': new Clock(new Date(Date.now() + 10000))} } />, model, controller);

--- a/src/view/RaceStartConsole.js
+++ b/src/view/RaceStartConsole.js
@@ -33,7 +33,6 @@ function RaceStartConsole () {
     const [flagsWithNextAction, setFlagsWithNextAction] = useState([]);
     const [actions, setActions] = useState([]);
     const [message, setMessage] = useState(''); // feedback to user
-    // const [sessionStart, setSessionStart] = useState(new Date(Math.floor(Date.now() / 86400000) * 86400000 + 28800000));
     const [sessionStart, setSessionStart] = useState(() => {
         const sessionStart = new Date(Math.floor(Date.now() / 86400000) * 86400000 + 28800000); // create as 8:00 UTC intially
         sessionStart.setMinutes(sessionStart.getMinutes() + sessionStart.getTimezoneOffset()); // adjust to be equivalent to 8:00 local time

--- a/src/view/RaceStartConsole.js
+++ b/src/view/RaceStartConsole.js
@@ -22,6 +22,7 @@ import ActionListView from './ActionListView';
 import CollapsableContainer from './CollapsableContainer';
 import FlagControl from './FlagControl';
 import RaceType from '../model/domain-classes/race-type';
+import Clock from '../model/domain-classes/clock';
 
 /**
  * Provide Race Officer with information needed to successfully start races in a session
@@ -143,7 +144,7 @@ function RaceStartConsole () {
             </div>
             <p id="race-console-message" className={!message ? "hidden" : ""}>{message}</p>
             <CollapsableContainer heading={'Flags'}>
-                {flagsWithNextAction.map(flag => { return <FlagControl key={flag.flag.name} flag={flag.flag} timeToChange={flag.action ? flag.action.time.valueOf() - Date.now() : 0} /> })}
+                {flagsWithNextAction.map(flag => { return <FlagControl key={flag.flag.name} flag={flag.flag} timeToChange={flag.action ? flag.action.time.valueOf() - Clock.now() : 0} /> })} {/* use Clock.now to get adjusted time when synched to an external clock */}
             </CollapsableContainer>
             <CollapsableContainer heading={'Races'}>
                 {races.map(race => {

--- a/src/view/ScoringAbbreviation.js
+++ b/src/view/ScoringAbbreviation.js
@@ -60,15 +60,13 @@ function ScoringAbbreviation({value = '', onChange}) {
     }
 
     return (
-        <td>
-            <select value={sc} onClick={handleOnClick} onAuxClick={handleAuxClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}
-                onPointerUp={handlePointerUp} onPointerOut={handlePointerOut} onPointerLeave={handlePointerLeave} onPointerCancel={handleCancel} onChange={handleChange} >
-                <option></option>
-                <option>DNS</option>
-                <option>DSQ</option>
-                <option>RET</option>
-            </select>
-        </td>
+        <select className="race-entry-view-scoring-abbreviation" value={sc} onClick={handleOnClick} onAuxClick={handleAuxClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp} onPointerOut={handlePointerOut} onPointerLeave={handlePointerLeave} onPointerCancel={handleCancel} onChange={handleChange} >
+            <option></option>
+            <option>DNS</option>
+            <option>DSQ</option>
+            <option>RET</option>
+        </select>
     )
 }
 

--- a/src/view/ScoringAbbreviation.test.js
+++ b/src/view/ScoringAbbreviation.test.js
@@ -20,13 +20,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 it('renders', () => {
-    const tableRow = document.createElement('tr');
-    render(<ScoringAbbreviation />, {container: document.body.appendChild(tableRow)});
+    render(<ScoringAbbreviation />);
 });
 
 it('displays options for scoring abbreviations', () => {
-    const tableRow = document.createElement('tr');
-    render(<ScoringAbbreviation />, {container: document.body.appendChild(tableRow)});
+    render(<ScoringAbbreviation />);
     expect(screen.getByRole('option', {name: ''})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: /DNS/})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: /RET/})).toBeInTheDocument();
@@ -37,8 +35,7 @@ describe('selection is changed', () => {
     it('calls onChange callback provided as prop', async () => {
         const onChangeSpy = jest.fn();
         const user = userEvent.setup();
-        const tableRow = document.createElement('tr');
-        render(<ScoringAbbreviation onChange={onChangeSpy} />, {container: document.body.appendChild(tableRow)});
+        render(<ScoringAbbreviation onChange={onChangeSpy} />);
         const selectSA = screen.getByRole('combobox');
         await user.selectOptions(selectSA, 'DNS');
         expect(onChangeSpy).toHaveBeenCalled();

--- a/src/view/SetTimeForm.js
+++ b/src/view/SetTimeForm.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022-2024 BG Information Systems Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+
+import { useState } from 'react';
+
+let formatOptions = {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+};
+
+const timeFormat = new Intl.DateTimeFormat('en-GB', formatOptions);
+
+/**
+ * Get a time value from the user
+ * @param {Object} props
+ * @param {SetTimeForm~setTime} props.setTime callback to set time
+ * @param {ModalDialog~closeDialog} [props.closeParent] call this to close a dialog containing this form
+ */
+function SetTimeForm({ setTime, closeParent }) {
+    const [timeString, setTimeString] = useState(timeFormat.format(Date.now()));
+
+    function convertTimeStringToDate(timeString) {
+        const timeArray = timeString.split(':'); // hh:mm[:ss]
+        const day = Math.floor(Date.now() / 86400000) * 86400000;
+        const hours = timeArray[0] * 3600000;
+        const minutes = timeArray[1] * 60000;
+        const seconds = timeArray[2] ? timeArray[2] * 1000 : 0;
+        return new Date(day + hours + minutes + seconds);
+    }
+
+    function handleChange({ target }) {
+        const newTime = target.value ? target.value : 0;
+        setTimeString(newTime);
+    }
+
+    function handleSetTimeButtonClick(event) {
+        event.preventDefault();
+        setTime(convertTimeStringToDate(timeString));
+        if (closeParent) {
+            closeParent();
+        }
+    }
+
+    return (
+        <form action='' method='get'>
+            <div>
+                <label htmlFor="input-time" >Enter time:</label>
+                <input id="input-time" type="time" value={timeString} step="1" onChange={handleChange} />
+            </div>
+            <div>
+                {closeParent ? <button type='button' onClick={closeParent} >Cancel</button> : null}                
+                <button type='button' onClick={handleSetTimeButtonClick}>Set Time</button>
+            </div>
+        </form>
+    )
+}
+
+export default SetTimeForm;
+
+/**
+ * Action to take when AdjustCourseForm update laps button clicked
+ * @callback SetTimeForm~setTime
+ * @param {Date} time to set
+ */

--- a/src/view/SetTimeForm.test.js
+++ b/src/view/SetTimeForm.test.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022-2024 BG Information Systems Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SetTimeForm from './SetTimeForm';
+
+
+let formatOptions = {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+};
+const timeFormat = new Intl.DateTimeFormat('en-GB', formatOptions);
+
+it('renders', () => {
+    const testTimeString = timeFormat.format(Date.now());
+    const closeParentSpy = jest.fn();
+    render(<SetTimeForm closeParent = {closeParentSpy} />);
+    expect(screen.getByLabelText(/enter time/i)).toHaveValue(testTimeString);
+    expect(screen.getByRole('button', {name: /set time/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /cancel/i})).toBeInTheDocument();
+});
+
+it('displays new value entered for time', async () => {
+    const user = userEvent.setup();
+    render(<SetTimeForm />);
+    const timeInput = screen.getByLabelText(/enter time/i);
+
+    await act(async () => {
+        await user.clear(timeInput);
+        await user.type(timeInput, '0811'); // should include seconds but JSDom Input type=time does not appear to be recognising step value to set a seconds component into control
+    });
+    expect(timeInput).toHaveValue('08:11');
+});
+
+describe('when set time button clicked', () => {
+    it('calls function passed to setTime with time entered', async () => {
+        const setTimeSpy = jest.fn();
+        const user = userEvent.setup();
+        
+        render(<SetTimeForm setTime={setTimeSpy} />);
+        
+        const timeInput = screen.getByLabelText(/enter time/i);
+        const testTime = new Date(Math.floor(Date.now() / 86400000) * 86400000 + 3600000 * 8 + 60000 * 11);
+        await act(async () => {
+            await user.clear(timeInput);
+            await user.type(timeInput, '0811'); // should include seconds but JSDom Input type=time does not appear to be recognising step value to set a seconds component into control
+        });
+        await user.click(screen.getByRole('button', {name: /set time/i}));
+        expect(setTimeSpy).toHaveBeenCalledWith(testTime);
+    });
+});
+
+describe('when contained in a modal dialog', () => {
+    describe('when update laps button clicked', () => {
+        it('closes containing dialog', async () => {
+            const setTimeSpy = jest.fn();
+            const closeParentSpy = jest.fn();
+            const user = userEvent.setup();
+            
+            render(<SetTimeForm setTime={setTimeSpy} closeParent={closeParentSpy} />);
+            
+            const timeInput = screen.getByLabelText(/enter time/i);
+            await act(async () => {
+                await user.clear(timeInput);
+                await user.type(timeInput, '0811'); // should include seconds but JSDom Input type=time does not appear to be recognising step value to set a seconds component into control
+            });
+            await user.click(screen.getByRole('button', {name: /set time/i}));
+            expect(closeParentSpy).toHaveBeenCalled();
+        });
+    });
+    it('when cancelled it closes containing dialog', async () => {
+        const closeParentSpy = jest.fn();
+        const user = userEvent.setup();
+        
+        render(<SetTimeForm closeParent={closeParentSpy} />);
+        
+        const cancelButtton = screen.getByRole('button', {'name': /cancel/i});
+        await user.click(cancelButtton);
+        expect(closeParentSpy).toBeCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Enable position changing by dragging and dropping entries on race console
Adjust calculation of pursuit race starts to use current second rather than rounding up or down
Enable ability to synch time calculations against an external clock