### PR TITLE
Improve race entries view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2024.11.2.hf1",
+  "version": "2024.12.1.dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dinghy-racing-client-ng",
-      "version": "2024.11.2.hf1",
+      "version": "2024.12.1.dev",
       "dependencies": {
         "@stomp/stompjs": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2024.11.2.hf1",
+  "version": "2024.12.1.dev",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -268,12 +268,6 @@ function RaceEntriesView({ races }) {
                 <div className='w3-col m3' >
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('classSailNumber')}>By class & sail number</button>
                 </div>
-                {/* <div className='w3-col m2'>
-                    <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('lastThree')}>By last 3</button>
-                </div> */}
-                {/* <div className='w3-col m2'>
-                    <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('classLastThree')}>By class & last 3</button>
-                </div> */}
                 <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('lapTimes')}>By lap times</button>
                 </div>

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -280,9 +280,9 @@ function RaceEntriesView({ races }) {
                 <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('forecast')}>By forecast</button>
                 </div>
-                <div className='w3-col m2'>
+                <div className='w3-col m1'>
                     <button className='w3-btn w3-block w3-card' title='refresh' onClick={handleRefreshClick}>
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" height=".9em" viewBox="0 -960 960 960" width=".9em" fill="#5f6368"><path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/></svg>
                     </button>
                 </div>
             </div>

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -124,6 +124,17 @@ function RaceEntriesView({ races }) {
                     return (entry.position && weight === .5) ? entry.position : Date.now() * weight; // if entry doesn't have a position return a large number to put it to the bottom
                 });
                 break;
+            case 'forecast':
+                ordered = sortArray(Array.from(entriesMap.values()), (entry) => {
+                    const weighIfScoringAbbreviation = ['DNS', 'DSQ', 'RET'];
+                    let weight = 1;
+                    if (weighIfScoringAbbreviation.includes(entry.scoringAbbreviation)) {
+                        weight = weight * 2;
+                    }
+                    const lastLapTime = entry.sumOfLapTimes ? entry.sumOfLapTimes : 0;
+                    return (entry.race.plannedStartTime.valueOf() + lastLapTime + ((entry.race.duration / entry.race.plannedLaps) * entry.dinghy.dinghyClass.portsmouthNumber / 1000)) * weight;
+                });
+                break;
             default:
                 ordered = sortArray(Array.from(entriesMap.values()), (entry) => {
                     return [entry.dinghy.dinghyClass.name, Number(entry.dinghy.sailNumber)];
@@ -268,6 +279,9 @@ function RaceEntriesView({ races }) {
                 </div>
                 <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('position')}>By position</button>
+                </div>
+                <div className='w3-col m2'>
+                    <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('forecast')}>By forecast</button>
                 </div>
             </div>
             <div className='scrollable' >

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -268,12 +268,12 @@ function RaceEntriesView({ races }) {
                 <div className='w3-col m3' >
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('classSailNumber')}>By class & sail number</button>
                 </div>
-                <div className='w3-col m2'>
+                {/* <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('lastThree')}>By last 3</button>
-                </div>
-                <div className='w3-col m2'>
+                </div> */}
+                {/* <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('classLastThree')}>By class & last 3</button>
-                </div>
+                </div> */}
                 <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('lapTimes')}>By lap times</button>
                 </div>

--- a/src/view/RaceEntriesView.js
+++ b/src/view/RaceEntriesView.js
@@ -77,6 +77,9 @@ function RaceEntriesView({ races }) {
         }
     }, [model, races, updateEntries, entriesUpdateRequestAt]);
 
+    function handleRefreshClick() {
+        setEntriesUpdateRequestAt(Date.now());
+    }
     // return array of entries sorted according to selected sort order
     function sorted() {
         let ordered = [];
@@ -276,6 +279,11 @@ function RaceEntriesView({ races }) {
                 </div>
                 <div className='w3-col m2'>
                     <button className='w3-btn w3-block w3-card' onClick={() => setSortOrder('forecast')}>By forecast</button>
+                </div>
+                <div className='w3-col m2'>
+                    <button className='w3-btn w3-block w3-card' title='refresh' onClick={handleRefreshClick}>
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/></svg>
+                    </button>
                 </div>
             </div>
             <div className='scrollable' >

--- a/src/view/RaceEntriesView.test.js
+++ b/src/view/RaceEntriesView.test.js
@@ -40,10 +40,11 @@ it('renders', async () => {
     });
     expect(screen.getByRole('button', {name: /by sail number/i})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /by class & sail number/i})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: /by last 3/i})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: /by class & last 3/i})).toBeInTheDocument();
+    // expect(screen.getByRole('button', {name: /by last 3/i})).toBeInTheDocument();
+    // expect(screen.getByRole('button', {name: /by class & last 3/i})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /by lap times/i})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /by position/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /by forecast/i})).toBeInTheDocument();
     expect(screen.getByText(/1234/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Scorpion/i)[0]).toBeInTheDocument();
     expect(screen.getByText(/Chris marshaLL/i)).toBeInTheDocument();
@@ -149,61 +150,61 @@ describe('when sorting entries', () => {
         expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
         expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
     });
-    it('sorts by the last three digits of the sail number', async () => {
-        const entriesScorpionA = [
-            {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0,'url': 'http://localhost:8081/dinghyracing/api/entries/11'},
-            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'}
-        ];
-        const user = userEvent.setup();
-        const model = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(model, 'getEntriesByRace').mockImplementation((race) => {
-            if (race.name === 'Scorpion A') {
-                return Promise.resolve({'success': true, 'domainObject': entriesScorpionA});
-            }
-            else if (race.name === 'Graduate A') {
-                return Promise.resolve({'success': true, 'domainObject': entriesGraduateA});
-            }    
-        });
-        await act(async () => {
-            customRender(<RaceEntriesView races={[raceScorpionA, raceGraduateA]} />, model);
-        });
-        const sortByLastThreeButton = screen.getByRole('button', {'name': /by last 3/i});
-        await act(async () => {
-            await user.click(sortByLastThreeButton);
-        });
-        const raceEntryViews = document.getElementsByClassName('race-entry-view');
-        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
-        expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
-        expect(within(raceEntryViews[2]).getByText(/2928/)).toBeInTheDocument();
-    });
-    it('sorts by the dinghy class and last three digits of the sail number', async () => {
-        const entriesScorpionA = [
-            {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/11'},
-            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'}
-        ];
-        const user = userEvent.setup();
-        const model = new DinghyRacingModel(httpRootURL, wsRootURL);
-        jest.spyOn(model, 'getEntriesByRace').mockImplementation((race) => {
-            if (race.name === 'Scorpion A') {
-                return Promise.resolve({'success': true, 'domainObject': entriesScorpionA});
-            }
-            else if (race.name === 'Graduate A') {
-                return Promise.resolve({'success': true, 'domainObject': entriesGraduateA});
-            }    
-        });
-        await act(async () => {
-            customRender(<RaceEntriesView races={[raceScorpionA, raceGraduateA]} />, model);
-        });
+    // it('sorts by the last three digits of the sail number', async () => {
+    //     const entriesScorpionA = [
+    //         {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0,'url': 'http://localhost:8081/dinghyracing/api/entries/11'},
+    //         {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'}
+    //     ];
+    //     const user = userEvent.setup();
+    //     const model = new DinghyRacingModel(httpRootURL, wsRootURL);
+    //     jest.spyOn(model, 'getEntriesByRace').mockImplementation((race) => {
+    //         if (race.name === 'Scorpion A') {
+    //             return Promise.resolve({'success': true, 'domainObject': entriesScorpionA});
+    //         }
+    //         else if (race.name === 'Graduate A') {
+    //             return Promise.resolve({'success': true, 'domainObject': entriesGraduateA});
+    //         }    
+    //     });
+    //     await act(async () => {
+    //         customRender(<RaceEntriesView races={[raceScorpionA, raceGraduateA]} />, model);
+    //     });
+    //     const sortByLastThreeButton = screen.getByRole('button', {'name': /by last 3/i});
+    //     await act(async () => {
+    //         await user.click(sortByLastThreeButton);
+    //     });
+    //     const raceEntryViews = document.getElementsByClassName('race-entry-view');
+    //     expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+    //     expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
+    //     expect(within(raceEntryViews[2]).getByText(/2928/)).toBeInTheDocument();
+    // });
+    // it('sorts by the dinghy class and last three digits of the sail number', async () => {
+    //     const entriesScorpionA = [
+    //         {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/11'},
+    //         {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'}
+    //     ];
+    //     const user = userEvent.setup();
+    //     const model = new DinghyRacingModel(httpRootURL, wsRootURL);
+    //     jest.spyOn(model, 'getEntriesByRace').mockImplementation((race) => {
+    //         if (race.name === 'Scorpion A') {
+    //             return Promise.resolve({'success': true, 'domainObject': entriesScorpionA});
+    //         }
+    //         else if (race.name === 'Graduate A') {
+    //             return Promise.resolve({'success': true, 'domainObject': entriesGraduateA});
+    //         }    
+    //     });
+    //     await act(async () => {
+    //         customRender(<RaceEntriesView races={[raceScorpionA, raceGraduateA]} />, model);
+    //     });
         
-        const sortByClassAndLastThreeButton = screen.getByRole('button', {'name': /by class & last 3/i});
-        await act(async () => {
-            await user.click(sortByClassAndLastThreeButton);
-        });
-        const raceEntryViews = document.getElementsByClassName('race-entry-view');
-        expect(within(raceEntryViews[0]).getByText(/2928/)).toBeInTheDocument();
-        expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
-        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
-    });
+    //     const sortByClassAndLastThreeButton = screen.getByRole('button', {'name': /by class & last 3/i});
+    //     await act(async () => {
+    //         await user.click(sortByClassAndLastThreeButton);
+    //     });
+    //     const raceEntryViews = document.getElementsByClassName('race-entry-view');
+    //     expect(within(raceEntryViews[0]).getByText(/2928/)).toBeInTheDocument();
+    //     expect(within(raceEntryViews[1]).getByText(/1234/)).toBeInTheDocument();
+    //     expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
+    // });
     it('sorts by the total recorded lap times plus race start time of dinghies in ascending order', async () => {
         const entries = [
             {'helm': competitorJillMyer, 'crew': null, 'race': raceGraduateA,'dinghy': dinghy2928, 'laps': [

--- a/src/view/RaceEntriesView.test.js
+++ b/src/view/RaceEntriesView.test.js
@@ -232,6 +232,33 @@ describe('when sorting entries', () => {
         expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
         expect(within(raceEntryViews[2]).getByText(/2928/)).toBeInTheDocument();
     });
+    it('sorts by estimation of next lap finish time', async () => {
+        const entriesScorpionA = [
+            {'helm': competitorSarahPascal,'race': raceScorpionA,'dinghy': dinghy6745, 'laps': [{number: 1, time: 562000}], 'sumOfLapTimes': 562000,'url': 'http://localhost:8081/dinghyracing/api/entries/11'},
+            {'helm': competitorChrisMarshall,'race': raceScorpionA,'dinghy': dinghy1234, 'laps': [], 'sumOfLapTimes': 0, 'url': 'http://localhost:8081/dinghyracing/api/entries/10'}
+        ];
+        const user = userEvent.setup();
+        const model = new DinghyRacingModel(httpRootURL, wsRootURL);
+        jest.spyOn(model, 'getEntriesByRace').mockImplementation((race) => {
+            if (race.name === 'Scorpion A') {
+                return Promise.resolve({'success': true, 'domainObject': entriesScorpionA});
+            }
+            else if (race.name === 'Graduate A') {
+                return Promise.resolve({'success': true, 'domainObject': entriesGraduateA});
+            }    
+        });
+        await act(async () => {
+            customRender(<RaceEntriesView races={[raceScorpionA, raceGraduateA]} />, model);
+        });
+        const sortByForecast = screen.getByRole('button', {'name': /by forecast/i});
+        await act(async () => {
+            await user.click(sortByForecast);
+        });
+        const raceEntryViews = document.getElementsByClassName('race-entry-view');
+        expect(within(raceEntryViews[0]).getByText(/1234/)).toBeInTheDocument();
+        expect(within(raceEntryViews[1]).getByText(/2928/)).toBeInTheDocument();
+        expect(within(raceEntryViews[2]).getByText(/6745/)).toBeInTheDocument();
+    });
     describe('when sorting by position', () => {
         it('sorts by position in ascending order', async () => {
             const entries = [
@@ -392,6 +419,7 @@ describe('when sorting entries', () => {
             expect(within(raceEntryViews[1]).getByText(/6745/)).toBeInTheDocument();
         });
     });
+
 });
 
 describe('when adding a lap time', () => {

--- a/src/view/RaceEntriesView.test.js
+++ b/src/view/RaceEntriesView.test.js
@@ -807,7 +807,10 @@ describe('when setting a scoring abbreviation', () => {
             customRender(<RaceEntriesView races={[{...raceScorpionA}]} />, model, controller);
         });
         const selectSA = screen.getAllByRole('combobox')[0];
-        await user.selectOptions(selectSA, 'DNS');
+        await act(async() => {
+            await user.selectOptions(selectSA, 'DNS');
+        });
+        
         expect(setScoringAbbreviationSpy).toBeCalledWith(entryChrisMarshallScorpionA1234, 'DNS');
     });
     it('displays a message if there is a problem updating the lap time', async () => {

--- a/src/view/RaceEntryView.js
+++ b/src/view/RaceEntryView.js
@@ -33,6 +33,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     const [disabled, setDisabled] = useState(false);
     const prevLapCount = useRef(entry.laps.length);
     const prevPosition = useRef(entry.position);
+    const prevSumOfLapTimes = useRef(entry.sumOfLapTimes);
     const lapsView = [];
     let classes = 'race-entry-view w3-row w3-border w3-hover-border-blue cursor-pointer preserve-whitespace';
 
@@ -47,6 +48,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     const handleLastLapCellKeyUp = useCallback((event) => {
         if (event.key === 'Enter') {
             if (updateLap) {
+                setDisabled(true);
                 updateLap(entry, event.target.value);
                 setEditMode(false);
             }
@@ -61,9 +63,11 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     }, []);
 
     useEffect(() => {
-        if (prevLapCount.current !== entry.laps.length || prevPosition !== entry.position) {
+        if (prevLapCount.current !== entry.laps.length || prevPosition.current !== entry.position || prevSumOfLapTimes.current !== entry.sumOfLapTimes) {
             setDisabled(false);
             prevLapCount.current = entry.laps.length;
+            prevPosition.current = entry.position;
+            prevSumOfLapTimes.current = entry.sumOfLapTimes;
         }
     }, [entry]);
 
@@ -71,6 +75,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
         if (!editMode && !disabled) {
             if (event.button === 0 && event.ctrlKey) {
                 if (removeLap) {
+                    setDisabled(true);
                     removeLap(entry);
                 }    
             }
@@ -159,6 +164,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
 
     function handleScoringAbbreviationSelection(event) {
         if (setScoringAbbreviation) {
+            setDisabled(true);
             setScoringAbbreviation(entry, event.target.value);
         }
     }
@@ -176,6 +182,7 @@ function RaceEntryView({entry, addLap, removeLap, updateLap, setScoringAbbreviat
     function dropHandler(event) {
         event.preventDefault();
         if (onRaceEntryDrop) {
+            setDisabled(true);
             onRaceEntryDrop(event.dataTransfer.getData('text/html'), entry.dinghy.dinghyClass.name + entry.dinghy.sailNumber + entry.helm.name);
         }
     }

--- a/src/view/SignUp.test.js
+++ b/src/view/SignUp.test.js
@@ -9488,11 +9488,13 @@ describe('when a previous entry is selected', () => {
             await user.selectOptions(inputDinghyClass, 'Scorpion');
             await user.type(inputSailNumber, '7654');
             await user.type(inputHelm, 'J R Hartley');
+        });
+        // seperate entry of crew name to allow check on dinghy class crew size to complete and setup form
+        await act(async () => {
             await user.type(inputCrew, 'Bilbo Baggins');
         });
-        // await screen.findByText(/bilbo baggins/i);
-        // screen.debug();
-        // get table that is supposed to contain details of dinghy class and previous crews
+        // confirm there is a crew value to be replaced
+        expect(inputCrew).toHaveValue('Bilbo Baggins');
         const previousEntries = within(screen.getByTestId('previous-entries'));
         const competitorCell = await previousEntries.findByRole('cell', {name: /bob hoskins/i});
         await act(async () => {

--- a/src/view/SignUp.test.js
+++ b/src/view/SignUp.test.js
@@ -547,8 +547,12 @@ describe('when signing up for a race', () => {
         });
         
         it('clears form on success', async () => {
-            const onSignupToRaceSpy = jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
+            jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
                 return Promise.resolve({'success': true});
+            });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
             });
             const user = userEvent.setup();
             customRender(<SignUp race={raceCometA}/>, model, controller);
@@ -559,6 +563,7 @@ describe('when signing up for a race', () => {
             });
             await act(async () => {
                 await user.type(inputSailNumber, '826');
+                await user.keyboard('{Tab}');
             });
             const buttonCreate = screen.getByRole('button', {'name': /sign-up/i});
             await act(async () => {
@@ -566,10 +571,12 @@ describe('when signing up for a race', () => {
             });
             const raceTitle = screen.getByRole('heading', {'name': /comet a/i});
             const btnCreate = screen.getByRole('button', {'name': /sign-up/i});
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(raceTitle).toBeInTheDocument();
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(screen.queryByLabelText(/crew/i)).toBeDisabled();
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(btnCreate).toBeInTheDocument();
         });
         
@@ -2059,8 +2066,12 @@ describe('when signing up for a race', () => {
         });
     
         it('clears form on success', async () => {
-            const onSignupToRaceSpy = jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
+            jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
                 return Promise.resolve({'success': true});
+            });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
             });
             const user = userEvent.setup();
             customRender(<SignUp race={raceScorpionA}/>, model, controller);
@@ -2072,6 +2083,7 @@ describe('when signing up for a race', () => {
             });
             await act(async () => {
                 await user.type(inputSailNumber, '1234');
+                await user.keyboard('{Tab}');
             });
             await act(async () => {
                 await user.type(inputCrew, 'Lou Screw');
@@ -2082,10 +2094,12 @@ describe('when signing up for a race', () => {
             });
             const raceTitle = screen.getByRole('heading', {'name': /scorpion a/i});
             const btnCreate = screen.getByRole('button', {'name': /sign-up/i});
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(raceTitle).toBeInTheDocument();
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(inputCrew).toHaveValue('');
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(btnCreate).toBeInTheDocument();
         });
         
@@ -4294,8 +4308,12 @@ describe('when signing up for a race', () => {
         });
     
         it('clears form on success', async () => {
-            const onSignupToRaceSpy = jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
+            jest.spyOn(controller, 'signupToRace').mockImplementation(() => {
                 return Promise.resolve({'success': true});
+            });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
             });
             const user = userEvent.setup();
             customRender(<SignUp race={raceHandicapA}/>, model, controller);
@@ -4312,6 +4330,7 @@ describe('when signing up for a race', () => {
             });
             await act(async () => {
                 await user.type(inputSailNumber, '1234');
+                await user.keyboard('{Tab}');
             });
             await act(async () => {
                 await user.type(inputCrew, 'Lou Screw');
@@ -4322,10 +4341,12 @@ describe('when signing up for a race', () => {
             });
             const raceTitle = screen.getByRole('heading', {'name': /handicap a/i});
             const btnCreate = screen.getByRole('button', {'name': /sign-up/i});
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(raceTitle).toBeInTheDocument();
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(inputCrew).toHaveValue('');
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(btnCreate).toBeInTheDocument();
         });
         
@@ -4938,6 +4959,10 @@ describe('when updating an existing entry', () => {
             jest.spyOn(controller, 'updateEntry').mockImplementation(() => {
                 return Promise.resolve({'success': true});
             });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
+            });
             const user = userEvent.setup();
             customRender(<SignUp race={raceCometA}/>, model, controller);
             const cellJillMyer = await screen.findByRole('cell', {name: /jill myer/i});
@@ -4953,14 +4978,17 @@ describe('when updating an existing entry', () => {
             await act(async () => {
                 await user.clear(inputSailNumber);
                 await user.type(inputSailNumber, '1234');
+                await user.keyboard('{Tab}');
             });
             const updateButton = screen.getByRole('button', {'name': /update/i});
             await act(async () => {
                 await user.click(updateButton);
             });
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(screen.queryByLabelText(/crew/i)).toBeDisabled();
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(screen.getByRole('button', {'name': /sign-up/i})).toBeInTheDocument();
         });
     });    
@@ -6724,6 +6752,10 @@ describe('when updating an existing entry', () => {
             jest.spyOn(controller, 'updateEntry').mockImplementation(() => {
                 return Promise.resolve({'success': true});
             });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
+            });
             const user = userEvent.setup();
             customRender(<SignUp race={raceScorpionA}/>, model, controller);
             const cellChrisMarshall = await screen.findByRole('cell', {name: /chris marshall/i});
@@ -6740,6 +6772,7 @@ describe('when updating an existing entry', () => {
             await act(async () => {
                 await user.clear(inputSailNumber);
                 await user.type(inputSailNumber, '826');
+                await user.keyboard('{Tab}');
             });
             await act(async () => {
                 await user.clear(inputCrew);
@@ -6749,10 +6782,12 @@ describe('when updating an existing entry', () => {
             await act(async () => {
                 await user.click(updateButton);
             });
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(screen.getByRole('heading', {'name': /scorpion a/i})).toBeInTheDocument();
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(inputCrew).toHaveValue('');
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(screen.getByRole('button', {'name': /sign-up/i})).toBeInTheDocument();
         });
     });    
@@ -9215,6 +9250,10 @@ describe('when updating an existing entry', () => {
             jest.spyOn(controller, 'updateEntry').mockImplementation(() => {
                 return Promise.resolve({'success': true});
             });
+            jest.spyOn(model, 'getDinghiesBySailNumber').mockImplementation(() => {return Promise.resolve({success: true, domainObject: [ dinghy1234 ]})});
+            jest.spyOn(model, 'getCrewsByDinghy').mockImplementation(() => {
+                return Promise.resolve({success: true, domainObject: dinghyScorpion1234Crews});
+            });
             const user = userEvent.setup();
             customRender(<SignUp race={raceHandicapA}/>, model, controller);
             const cellChrisMarshall = await screen.findByRole('cell', {name: /chris marshall/i});
@@ -9236,6 +9275,7 @@ describe('when updating an existing entry', () => {
             await act(async () => {
                 await user.clear(inputSailNumber);
                 await user.type(inputSailNumber, '1234');
+                await user.keyboard('{Tab}');
             });
             await act(async () => {
                 await user.clear(inputCrew);
@@ -9247,10 +9287,12 @@ describe('when updating an existing entry', () => {
             });
             const raceTitle = screen.getByRole('heading', {'name': /handicap a/i});
             const btnCreate = screen.getByRole('button', {'name': /sign-up/i});
+            const previousEntries = within(screen.getByTestId('previous-entries'));
             expect(raceTitle).toBeInTheDocument();
             expect(inputHelm).toHaveValue('');
             expect(inputSailNumber).toHaveValue('');
             expect(inputCrew).toHaveValue('');
+            expect(previousEntries.getAllByRole('row')).toHaveLength(1);
             expect(btnCreate).toBeInTheDocument();
         });
     });


### PR DESCRIPTION
Add sort by lap forecast option to race entries view
Remove unused sort option from race entries view
Show entry as disabled when updating lap time, removing lap time, or setting scoring abbreviation
Add a refresh entries option