### PR TITLE
move default end time for display of upcoming races to 20:00

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2025.5.1",
+  "version": "2025.5.2.dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dinghy-racing-client-ng",
-      "version": "2025.5.1",
+      "version": "2025.5.2.dev",
       "dependencies": {
         "@stomp/stompjs": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinghy-racing-client-ng",
-  "version": "2025.5.1",
+  "version": "2025.5.2.dev",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/view/ViewUpcomingRaces.js
+++ b/src/view/ViewUpcomingRaces.js
@@ -30,7 +30,7 @@ function ViewUpcomingRaces({ showSignUpForm = false }) {
     const model = useContext(ModelContext);
     const [sessionStart, setSessionStart] = useState(new Date());
     const [sessionEnd, setSessionEnd] = useState(() => {
-        const sessionEnd = new Date(Math.floor(Date.now() / 86400000) * 86400000 + 64800000); // create as 18:00 UTC intially
+        const sessionEnd = new Date(Math.floor(Date.now() / 86400000) * 86400000 + 72000000); // create as 20:00 UTC intially
         sessionEnd.setMinutes(sessionEnd.getMinutes() + sessionEnd.getTimezoneOffset()); // adjust to be equivalent to 18:00 local time
         return sessionEnd;
     });

--- a/src/view/ViewUpcomingRaces.test.js
+++ b/src/view/ViewUpcomingRaces.test.js
@@ -54,7 +54,7 @@ it('defaults start time for race selection to now', async () => {
     expect(screen.getByLabelText(/session start/i)).toHaveValue(now.toISOString().substring(0, 16));
 });
 
-it('defaults end time for race selection to 18:00 today', async () => {
+it('defaults end time for race selection to 20:00 today', async () => {
     const model = new DinghyRacingModel(httpRootURL, wsRootURL);
 
     jest.spyOn(model, 'getRacesBetweenTimes').mockImplementationOnce(() => {return Promise.resolve({'success': true, 'domainObject': []})});
@@ -62,7 +62,7 @@ it('defaults end time for race selection to 18:00 today', async () => {
         await customRender(<ViewUpcomingRaces />, model);
     });
     
-    expect(screen.getByLabelText(/session end/i)).toHaveValue(new Date(Math.floor(Date.now() / 86400000) * 86400000 + 64800000).toISOString().substring(0, 16));
+    expect(screen.getByLabelText(/session end/i)).toHaveValue(new Date(Math.floor(Date.now() / 86400000) * 86400000 + 72000000).toISOString().substring(0, 16));
 });
 
 // test could be affected by date time local settings


### PR DESCRIPTION
move default end time for display of upcoming races to 20:00